### PR TITLE
New: [AEA-5546] - Use prompts for better answers

### DIFF
--- a/packages/cdk/nagSuppressions.ts
+++ b/packages/cdk/nagSuppressions.ts
@@ -98,7 +98,7 @@ export const nagSuppressions = (stack: Stack) => {
         appliesTo: [
           "Action::bedrock:Delete*",
           "Resource::<StorageDocsBucketepsamDocsF25F63F1.Arn>/*",
-          "Resource::<StorageDocsBucketepsampr16Docs240CC945.Arn>/*",
+          "Resource::<StorageDocsBucketepsampr26DocsEF3936E5.Arn>/*",
           `Resource::arn:aws:bedrock:eu-west-2:${account}:knowledge-base/*`,
           `Resource::arn:aws:aoss:eu-west-2:${account}:collection/*`,
           "Resource::*"


### PR DESCRIPTION
## Summary

🎫 [AEA-5546](https://nhsd-jira.digital.nhs.uk/browse/AEA-5546) Use prompts for better answers

:sparkles: New Feature
:robot: Operational or Infrastructure Change

### Details

This change improves the relevance of Slack bot answers by introducing a prompt-building and query-rewriting layer before sending user questions to Bedrock’s Knowledge Base retrieve_and_generate API.

Key updates:

- Added system prompt to instruct Bedrock on response style, source restrictions, and EPS/NHS domain behaviour.
- Implemented query rewriting to:
  - Strip Slack-specific noise (mentions, emojis, formatting).
  - Expand EPS/NHS domain acronyms and terminology.
  - Normalize and clarify vague user input.
- Modified get_bedrock_knowledgebase_response to send the prompt + rewritten query instead of the raw Slack message.
- Externalised prompt content for easier iteration without code changes.
- Added logging to compare original vs rewritten queries and help with post-deployment tuning.

Outcome: Bedrock receives clearer, more context-rich queries, resulting in answers that are more relevant and better grounded in the knowledge base.