### PR TITLE
New: [AEA-5696] - Add feedback into EPS Assist Me

### DIFF
--- a/packages/slackBotFunction/tests/test_app.py
+++ b/packages/slackBotFunction/tests/test_app.py
@@ -274,9 +274,14 @@ def test_process_async_slack_event_success(
 
         process_async_slack_event(slack_event_data)
 
-        mock_client.chat_postMessage.assert_called_once_with(
-            channel="C789", text="AI response", thread_ts="1234567890.123"
-        )
+        # Verify the call was made with feedback blocks
+        mock_client.chat_postMessage.assert_called_once()
+        call_args = mock_client.chat_postMessage.call_args
+        assert call_args[1]["channel"] == "C789"
+        assert call_args[1]["text"] == "AI response"
+        assert call_args[1]["thread_ts"] == "1234567890.123"
+        assert "blocks" in call_args[1]
+        assert len(call_args[1]["blocks"]) == 3  # section, actions, context
 
 
 @patch("aws_lambda_powertools.utilities.parameters.get_parameter")


### PR DESCRIPTION
## Summary

🎫 [AEA-5696](https://nhsd-jira.digital.nhs.uk/browse/AEA-5696) Add feedback into EPS Assist Me

:sparkles: New Feature

### Details

Add a feedback mechanism to EPS Assist Me so that after a supplier receives an answer, they are asked “Was this helpful?”. If they select `Yes`, the response is stored and a thank-you message is shown, and if they select `No`, they are prompted to provide written feedback.