### PR TITLE
Fix: [AEA-6533] - Handle Modification of User Messages

### DIFF
--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -3,6 +3,7 @@ Slack event processing
 Handles conversation memory, Bedrock queries, and responding back to Slack
 """
 
+from decimal import Decimal
 import re
 import time
 import traceback
@@ -497,6 +498,50 @@ def process_pull_request_slack_action(slack_body_data: Dict[str, Any]) -> None:
 # ================================================================
 
 
+def _clear_thread_replies(
+    client: WebClient,
+    channel: str,
+    thread_ts: str,
+    original_ts: str,
+    edited_event: Dict[str, Any],
+    event_id: str,
+) -> None:
+    """Clear subsequent bot replies in a thread when the original message is edited."""
+    try:
+        logger.info("Existing conversation found", extra={"event": edited_event})
+        current_thread = client.conversations_replies(channel=channel, ts=thread_ts)
+
+        thread_messages = current_thread.get("messages", [])
+
+        if len(thread_messages) > 1:
+            # Get the original message timestamp
+            previous_edit_ts = Decimal(original_ts)
+
+            logger.info(
+                "Found existing thread, clearing replies",
+                extra={"channel": channel, "thread_ts": thread_ts, "previous_edit_ts": previous_edit_ts},
+            )
+
+            for reply in thread_messages[1:]:
+                # If the message is after the original message, delete it
+                reply_ts = Decimal(reply.get("ts"))
+                if reply_ts > previous_edit_ts:
+                    try:
+                        client.chat_delete(channel=channel, ts=reply_ts)
+                    except Exception as e:
+                        logger.error(
+                            f"Couldn't delete message: {e}",
+                            extra={"event_id": event_id, "error": traceback.format_exc()},
+                        )
+
+            logger.info(f"Deleted {len(thread_messages) - 1} replies")
+    except Exception as e:
+        logger.error(
+            f"Error modifying existing messages: {e}",
+            extra={"event_id": event_id, "error": traceback.format_exc()},
+        )
+
+
 def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClient) -> None:
     """
     Process Slack events asynchronously after initial acknowledgment
@@ -527,27 +572,14 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
             return
 
         if edited_event:
-            logger.info("Existing conversation found", extra={"event": edited_event})
-            current_thread = client.conversations_replies(channel=channel, ts=thread_ts)
-
-            thread_messages = current_thread.get("messages", [])
-
-            if len(thread_messages) > 1:
-                # Get the original message timestamp
-                previous_edit_ts = event["ts"]
-
-                logger.info(
-                    "Found existing thread, clearing replies",
-                    extra={"channel": channel, "thread_ts": thread_ts, "previous_edit_ts": previous_edit_ts},
-                )
-
-                for reply in thread_messages[1:]:
-                    # If the message is after the original message, delete it
-                    reply_ts = reply.get("ts")
-                    if reply_ts > previous_edit_ts:
-
-                        client.delete(channel=channel, ts=reply_ts)
-                logger.info(f"Deleted {len(thread_messages) - 1} replies")
+            _clear_thread_replies(
+                client=client,
+                channel=channel,
+                thread_ts=thread_ts,
+                original_ts=event["ts"],
+                edited_event=edited_event,
+                event_id=event_id,
+            )
 
         # conversation continuity: reuse bedrock session across slack messages
         session_data = get_conversation_session_data(conversation_key)
@@ -581,7 +613,8 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
         store_qa_pair(conversation_key, user_query, response_text, message_ts, kb_response.get("sessionId"), user_id)
 
         try:
-            client.chat_update(channel=channel, ts=message_ts, text=response_text, blocks=blocks)
+            response = client.chat_update(channel=channel, ts=message_ts, text=response_text, blocks=blocks)
+            logger.info("Chat Updated", extra={"response": response})
         except Exception as e:
             logger.error(
                 f"Failed to update message: {e}",

--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -401,6 +401,7 @@ def process_async_slack_event(event: Dict[str, Any], event_id: str, client: WebC
     conversation_key, thread_ts = conversation_key_and_root(event)
     user_id = event.get("user", "unknown")
     channel_id = event["channel"]
+
     conversation_key, thread_root = conversation_key_and_root(event=event)
     if message_text.lower().startswith(constants.PULL_REQUEST_PREFIX):
         try:
@@ -507,6 +508,7 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
         user_id = event["user"]
         channel = event["channel"]
         conversation_key, thread_ts = conversation_key_and_root(event)
+        edited_event = event["edited"]
 
         # Remove Slack user mentions from message text
         user_query = re.sub(r"<@[UW][A-Z0-9]+(\|[^>]+)?>", "", event["text"]).strip()
@@ -523,6 +525,23 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
                 post_params["thread_ts"] = thread_ts
             client.chat_postMessage(**post_params)
             return
+        
+        if edited_event:
+            existing_thread = client.conversation_replied(
+                channel=channel,
+                ts=edited_event["ts"]
+            )
+
+            if len(existing_thread) > 1:
+                logger.info("Found existing thread, clearing replies")
+                for reply in existing_thread[1:]:
+                    reply_ts = reply.get("ts")
+
+                    client.delete(
+                        channel=channel,
+                        ts=reply_ts
+                    )
+                logger.info(f"Deleted {existing_thread - 1} replies")
 
         # conversation continuity: reuse bedrock session across slack messages
         session_data = get_conversation_session_data(conversation_key)

--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -508,7 +508,7 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
         user_id = event["user"]
         channel = event["channel"]
         conversation_key, thread_ts = conversation_key_and_root(event)
-        edited_event = event["edited"]
+        edited_event = event.get("edited")
 
         # Remove Slack user mentions from message text
         user_query = re.sub(r"<@[UW][A-Z0-9]+(\|[^>]+)?>", "", event["text"]).strip()
@@ -525,23 +525,19 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
                 post_params["thread_ts"] = thread_ts
             client.chat_postMessage(**post_params)
             return
-        
-        if edited_event:
-            existing_thread = client.conversation_replied(
-                channel=channel,
-                ts=edited_event["ts"]
-            )
 
-            if len(existing_thread) > 1:
+        if edited_event:
+            existing_thread = client.conversations_replies(channel=channel, ts=edited_event["ts"])
+
+            thread_messages = existing_thread.get("messages", [])
+
+            if len(thread_messages) > 1:
                 logger.info("Found existing thread, clearing replies")
-                for reply in existing_thread[1:]:
+                for reply in thread_messages[1:]:
                     reply_ts = reply.get("ts")
 
-                    client.delete(
-                        channel=channel,
-                        ts=reply_ts
-                    )
-                logger.info(f"Deleted {existing_thread - 1} replies")
+                    client.delete(channel=channel, ts=reply_ts)
+                logger.info(f"Deleted {len(thread_messages) - 1} replies")
 
         # conversation continuity: reuse bedrock session across slack messages
         session_data = get_conversation_session_data(conversation_key)

--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -498,8 +498,43 @@ def process_pull_request_slack_action(slack_body_data: Dict[str, Any]) -> None:
 # ================================================================
 
 
+def _notify_diverged_conversation(client, channel: str, user_id: str, thread_ts: str, event_id: str) -> None:
+    """Helper to post an ephemeral message if the conversation diverged."""
+    try:
+        client.chat_postEphemeral(
+            channel=channel,
+            user=user_id,
+            thread_ts=thread_ts,
+            text="It looks like the conversation has diverged, please start a new conversation",
+        )
+    except Exception as e:
+        logger.error(
+            f"Couldn't post ephemeral message: {e}",
+            extra={"event_id": event_id, "error": traceback.format_exc()},
+        )
+
+
+def _delete_subsequent_replies(client, channel: str, messages: list, event_id: str) -> int:
+    """Helper to iterate through and delete bot replies."""
+    deleted_count = 0
+    for reply in messages:
+        reply_ts = reply.get("ts")
+        if not reply_ts:
+            continue
+
+        try:
+            client.chat_delete(channel=channel, ts=reply_ts)
+            deleted_count += 1
+        except Exception as e:
+            logger.error(
+                f"Couldn't delete message: {e}",
+                extra={"event_id": event_id, "error": traceback.format_exc()},
+            )
+    return deleted_count
+
+
 def _handle_modified_messages(
-    client: WebClient,
+    client,  # Type hint with your WebClient
     channel: str,
     thread_ts: str,
     original_ts: str,
@@ -511,56 +546,32 @@ def _handle_modified_messages(
     try:
         logger.info("Existing conversation found", extra={"event": edited_event})
         current_thread = client.conversations_replies(channel=channel, ts=thread_ts)
-
         thread_messages = current_thread.get("messages", [])
 
-        if len(thread_messages) > 1:
-            # Get the original message timestamp
-            previous_edit_ts = Decimal(original_ts)
+        # Early return if there are no subsequent messages
+        if len(thread_messages) <= 1:
+            return True
 
-            # Filter messages that came after the edited message
-            subsequent_messages = [msg for msg in thread_messages if Decimal(msg.get("ts", "0")) > previous_edit_ts]
+        previous_edit_ts = Decimal(original_ts)
+        subsequent_messages = [msg for msg in thread_messages if Decimal(msg.get("ts", "0")) > previous_edit_ts]
 
-            # Check if there are any subsequent messages from the user
-            has_user_replies = any(msg.get("user") == user_id for msg in subsequent_messages)
+        has_user_replies = any(msg.get("user") == user_id for msg in subsequent_messages)
 
-            if has_user_replies:
-                # Not the last user message in the chain
-                try:
-                    client.chat_postEphemeral(
-                        channel=channel,
-                        user=user_id,
-                        thread_ts=thread_ts,
-                        text="It looks like the conversation has diverged, please start a new conversation",
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Couldn't post ephemeral message: {e}",
-                        extra={"event_id": event_id, "error": traceback.format_exc()},
-                    )
-                return False
-            else:
-                logger.info(
-                    "Found existing thread, clearing replies",
-                    extra={"channel": channel, "thread_ts": thread_ts, "previous_edit_ts": previous_edit_ts},
-                )
-                deleted_count = 0
-                for reply in subsequent_messages:
-                    reply_ts = reply.get("ts")
-                    if reply_ts:
-                        try:
-                            client.chat_delete(channel=channel, ts=reply_ts)
-                            deleted_count += 1
-                        except Exception as e:
-                            logger.error(
-                                f"Couldn't delete message: {e}",
-                                extra={"event_id": event_id, "error": traceback.format_exc()},
-                            )
+        if has_user_replies:
+            _notify_diverged_conversation(client, channel, user_id, thread_ts, event_id)
+            return False
 
-                logger.info(f"Deleted {deleted_count} replies")
-                return True
+        # If no user replies, proceed with deletion
+        logger.info(
+            "Found existing thread, clearing replies",
+            extra={"channel": channel, "thread_ts": thread_ts, "previous_edit_ts": previous_edit_ts},
+        )
+
+        deleted_count = _delete_subsequent_replies(client, channel, subsequent_messages, event_id)
+        logger.info(f"Deleted {deleted_count} replies")
 
         return True
+
     except Exception as e:
         logger.error(
             f"Error modifying existing messages: {e}",

--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -527,16 +527,26 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
             return
 
         if edited_event:
-            existing_thread = client.conversations_replies(channel=channel, ts=edited_event["ts"])
+            logger.info("Existing conversation found", extra={"event": edited_event})
+            current_thread = client.conversations_replies(channel=channel, ts=thread_ts)
 
-            thread_messages = existing_thread.get("messages", [])
+            thread_messages = current_thread.get("messages", [])
 
             if len(thread_messages) > 1:
-                logger.info("Found existing thread, clearing replies")
-                for reply in thread_messages[1:]:
-                    reply_ts = reply.get("ts")
+                # Get the original message timestamp
+                previous_edit_ts = event["ts"]
 
-                    client.delete(channel=channel, ts=reply_ts)
+                logger.info(
+                    "Found existing thread, clearing replies",
+                    extra={"channel": channel, "thread_ts": thread_ts, "previous_edit_ts": previous_edit_ts},
+                )
+
+                for reply in thread_messages[1:]:
+                    # If the message is after the original message, delete it
+                    reply_ts = reply.get("ts")
+                    if reply_ts > previous_edit_ts:
+
+                        client.delete(channel=channel, ts=reply_ts)
                 logger.info(f"Deleted {len(thread_messages) - 1} replies")
 
         # conversation continuity: reuse bedrock session across slack messages

--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -498,14 +498,15 @@ def process_pull_request_slack_action(slack_body_data: Dict[str, Any]) -> None:
 # ================================================================
 
 
-def _clear_thread_replies(
+def _handle_modified_messages(
     client: WebClient,
     channel: str,
     thread_ts: str,
     original_ts: str,
     edited_event: Dict[str, Any],
     event_id: str,
-) -> None:
+    user_id: str,
+) -> bool:
     """Clear subsequent bot replies in a thread when the original message is edited."""
     try:
         logger.info("Existing conversation found", extra={"event": edited_event})
@@ -517,29 +518,55 @@ def _clear_thread_replies(
             # Get the original message timestamp
             previous_edit_ts = Decimal(original_ts)
 
-            logger.info(
-                "Found existing thread, clearing replies",
-                extra={"channel": channel, "thread_ts": thread_ts, "previous_edit_ts": previous_edit_ts},
-            )
+            # Filter messages that came after the edited message
+            subsequent_messages = [msg for msg in thread_messages if Decimal(msg.get("ts", "0")) > previous_edit_ts]
 
-            for reply in thread_messages[1:]:
-                # If the message is after the original message, delete it
-                reply_ts = Decimal(reply.get("ts"))
-                if reply_ts > previous_edit_ts:
-                    try:
-                        client.chat_delete(channel=channel, ts=reply_ts)
-                    except Exception as e:
-                        logger.error(
-                            f"Couldn't delete message: {e}",
-                            extra={"event_id": event_id, "error": traceback.format_exc()},
-                        )
+            # Check if there are any subsequent messages from the user
+            has_user_replies = any(msg.get("user") == user_id for msg in subsequent_messages)
 
-            logger.info(f"Deleted {len(thread_messages) - 1} replies")
+            if has_user_replies:
+                # Not the last user message in the chain
+                try:
+                    client.chat_postEphemeral(
+                        channel=channel,
+                        user=user_id,
+                        thread_ts=thread_ts,
+                        text="It looks like the conversation has diverged, please start a new conversation",
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Couldn't post ephemeral message: {e}",
+                        extra={"event_id": event_id, "error": traceback.format_exc()},
+                    )
+                return False
+            else:
+                logger.info(
+                    "Found existing thread, clearing replies",
+                    extra={"channel": channel, "thread_ts": thread_ts, "previous_edit_ts": previous_edit_ts},
+                )
+                deleted_count = 0
+                for reply in subsequent_messages:
+                    reply_ts = reply.get("ts")
+                    if reply_ts:
+                        try:
+                            client.chat_delete(channel=channel, ts=reply_ts)
+                            deleted_count += 1
+                        except Exception as e:
+                            logger.error(
+                                f"Couldn't delete message: {e}",
+                                extra={"event_id": event_id, "error": traceback.format_exc()},
+                            )
+
+                logger.info(f"Deleted {deleted_count} replies")
+                return True
+
+        return True
     except Exception as e:
         logger.error(
             f"Error modifying existing messages: {e}",
             extra={"event_id": event_id, "error": traceback.format_exc()},
         )
+        return False
 
 
 def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClient) -> None:
@@ -572,14 +599,18 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
             return
 
         if edited_event:
-            _clear_thread_replies(
+            has_modified = _handle_modified_messages(
                 client=client,
                 channel=channel,
                 thread_ts=thread_ts,
                 original_ts=event["ts"],
                 edited_event=edited_event,
                 event_id=event_id,
+                user_id=user_id,
             )
+
+            if not has_modified:
+                return
 
         # conversation continuity: reuse bedrock session across slack messages
         session_data = get_conversation_session_data(conversation_key)

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
@@ -916,7 +916,7 @@ def test_process_slack_message_clears_existing_replies_on_edit(
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
     # Assertions to ensure it fetched the thread and deleted only the replies
-    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="original_123")
+    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="1234567890.123")
 
     assert mock_client.delete.call_count == 2
     mock_client.delete.assert_any_call(channel="C789", ts="reply_456")
@@ -963,5 +963,5 @@ def test_process_slack_message_no_replies_cleared_on_edit(
 
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="original_123")
+    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="1234567890.123")
     mock_client.delete.assert_not_called()

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
@@ -1043,3 +1043,35 @@ def test_process_slack_message_continues_on_true_modified_handler(mock_env: Mock
             text="AI response",
             blocks=ANY,
         )
+
+
+def test_notify_diverged_conversation_success():
+    """Test successful posting of the ephemeral warning message."""
+    mock_client = Mock()
+
+    from app.slack.slack_events import _notify_diverged_conversation
+
+    _notify_diverged_conversation(mock_client, "C123", "U123", "100.000", "evt123")
+
+    mock_client.chat_postEphemeral.assert_called_once_with(
+        channel="C123",
+        user="U123",
+        thread_ts="100.000",
+        text="It looks like the conversation has diverged, please start a new conversation",
+    )
+
+
+@patch("app.slack.slack_events.logger")
+def test_notify_diverged_conversation_exception(mock_logger):
+    """Test that exceptions during ephemeral posting are caught and logged."""
+    mock_client = Mock()
+    mock_client.chat_postEphemeral.side_effect = Exception("API error")
+
+    from app.slack.slack_events import _notify_diverged_conversation
+
+    # Should not raise an exception
+    _notify_diverged_conversation(mock_client, "C123", "U123", "100.000", "evt123")
+
+    mock_client.chat_postEphemeral.assert_called_once()
+    mock_logger.error.assert_called_once()
+    assert "Couldn't post ephemeral message: API error" in mock_logger.error.call_args[0][0]

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
@@ -1,6 +1,6 @@
 import sys
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import ANY, Mock, patch, MagicMock
 
 
 @pytest.fixture
@@ -873,98 +873,173 @@ def test_convert_markdown_to_slack_multiple_encoding_issues(mock_get_parameter: 
 # ================================================================
 
 
-@patch("app.services.dynamo.get_state_information")
-@patch("app.services.ai_processor.process_ai_query")
-@patch("app.slack.slack_events.get_conversation_session")
-def test_process_slack_message_clears_existing_replies_on_edit(
-    mock_get_session: Mock,
-    mock_process_ai_query: Mock,
-    mock_get_state_information: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test that editing a message clears previous bot replies in the thread"""
-    mock_client = Mock()
-    mock_client.chat_postMessage.return_value = {"ts": "123.124"}
-    mock_client.chat_update.return_value = {"ok": True}
+def test_handle_modified_messages_last_user_message_in_chain():
+    """If the message is the last in the chain, delete reply and continue"""
+    if "app.slack.slack_events" in sys.modules:
+        del sys.modules["app.slack.slack_events"]
+    from app.slack.slack_events import _handle_modified_messages
 
-    # Mocking the returned thread dict to simulate 1 original message and 2 replies
+    mock_client = Mock()
+    # Mock conversation history: Original user message + 2 Bot replies
     mock_client.conversations_replies.return_value = {
-        "messages": [{"ts": "997.999"}, {"ts": "998.999"}, {"ts": "999.999"}]
+        "messages": [
+            {"ts": "100.000", "user": "U123"},
+            {"ts": "101.000", "user": "BOT_ID"},
+            {"ts": "102.000", "user": "BOT_ID"},
+        ]
     }
 
-    mock_process_ai_query.return_value = {
-        "text": "AI response",
-        "session_id": "session-123",
-        "citations": [],
-        "kb_response": {"output": {"text": "AI response"}},
-    }
-    mock_get_session.return_value = None
+    result = _handle_modified_messages(
+        client=mock_client,
+        channel="C123",
+        thread_ts="100.000",
+        original_ts="100.000",
+        edited_event={"ts": "105.000"},
+        event_id="evt123",
+        user_id="U123",
+    )
 
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
-    from app.slack.slack_events import process_slack_message
-
-    slack_event_data = {
-        "text": "<@U123> updated question",
-        "user": "U456",
-        "channel": "C789",
-        "ts": "123.123",
-        "event_ts": "123.123",
-        "edited": {"user": "U456", "ts": "456.789"},
-    }
-
-    process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
-
-    # Assertions to ensure it fetched the thread and deleted only the replies
-    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="123.123")
-
-    from decimal import Decimal
-
+    # Assertions
+    assert result is True
     assert mock_client.chat_delete.call_count == 2
-    mock_client.chat_delete.assert_any_call(channel="C789", ts=Decimal("998.999"))
-    mock_client.chat_delete.assert_any_call(channel="C789", ts=Decimal("999.999"))
+    mock_client.chat_postEphemeral.assert_not_called()
 
 
-@patch("app.services.dynamo.get_state_information")
-@patch("app.services.ai_processor.process_ai_query")
-@patch("app.slack.slack_events.get_conversation_session")
-def test_process_slack_message_no_replies_cleared_on_edit(
-    mock_get_session: Mock,
-    mock_process_ai_query: Mock,
-    mock_get_state_information: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test that editing a message without replies doesn't trigger deletions"""
+def test_handle_modified_messages_not_last_user_message_in_chain():
+    """If the message is not the last user message, post ephemeral msg and return False"""
+    if "app.slack.slack_events" in sys.modules:
+        del sys.modules["app.slack.slack_events"]
+    from app.slack.slack_events import _handle_modified_messages
+
     mock_client = Mock()
-    mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
-    mock_client.chat_update.return_value = {"ok": True}
-
-    # Mocking a thread that only contains the original message (no replies)
-    mock_client.conversations_replies.return_value = {"messages": [{"ts": "original_123"}]}
-
-    mock_process_ai_query.return_value = {
-        "text": "AI response",
-        "session_id": "session-123",
-        "citations": [],
-        "kb_response": {"output": {"text": "AI response"}},
+    # Mock conversation history: Original message + Bot reply + Another user message (user replied again)
+    mock_client.conversations_replies.return_value = {
+        "messages": [
+            {"ts": "100.000", "user": "U123"},
+            {"ts": "101.000", "user": "BOT_ID"},
+            {"ts": "102.000", "user": "U123"},
+        ]
     }
-    mock_get_session.return_value = None
+
+    result = _handle_modified_messages(
+        client=mock_client,
+        channel="C123",
+        thread_ts="100.000",
+        original_ts="100.000",
+        edited_event={"ts": "105.000"},
+        event_id="evt123",
+        user_id="U123",
+    )
+
+    # Assertions
+    assert result is False
+    mock_client.chat_delete.assert_not_called()
+    mock_client.chat_postEphemeral.assert_called_once_with(
+        channel="C123",
+        user="U123",
+        thread_ts="100.000",
+        text="It looks like the conversation has diverged, please start a new conversation",
+    )
+
+
+def test_process_slack_message_halts_on_false_modified_handler(
+    mock_env: Mock,
+    mock_get_parameter: Mock,
+):
+    """Test that process_slack_message stops processing if the edit is rejected (not last in chain)"""
+    mock_client = Mock()
 
     if "app.slack.slack_events" in sys.modules:
         del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_slack_message
 
-    slack_event_data = {
-        "text": "<@U123> updated question",
-        "user": "U456",
-        "channel": "C789",
-        "ts": "1234567890.123",
-        "edited": {"user": "U456", "ts": "original_123"},
+    event = {
+        "text": "updated question",
+        "user": "U123",
+        "channel": "C123",
+        "ts": "123.123",
+        "edited": {"ts": "456.789"},
+        "thread_ts": "123.123",
     }
 
-    process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
+    # Patch dynamically inside the test body to avoid the module reload issue
+    with patch("app.slack.slack_events._handle_modified_messages") as mock_handle_modified_messages, patch(
+        "app.slack.slack_events.get_conversation_session_data"
+    ) as mock_get_conversation_session_data:
 
-    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="1234567890.123")
-    mock_client.chat_delete.assert_not_called()
+        mock_handle_modified_messages.return_value = False
+
+        process_slack_message(event=event, event_id="evt123", client=mock_client)
+
+        # Assertions
+        mock_handle_modified_messages.assert_called_once_with(
+            client=mock_client,
+            channel="C123",
+            thread_ts="123.123",
+            original_ts="123.123",
+            edited_event={"ts": "456.789"},
+            event_id="evt123",
+            user_id="U123",
+        )
+
+        # Ensure it stopped execution and didn't try to fetch conversation memory / call Bedrock
+        mock_get_conversation_session_data.assert_not_called()
+        mock_client.chat_postMessage.assert_not_called()
+
+
+def test_process_slack_message_continues_on_true_modified_handler(mock_env: Mock, mock_get_parameter: Mock):
+    """Test that process_slack_message completes if the edit is accepted"""
+    mock_client = Mock()
+    # Mock the response for the "Processing..." message
+    mock_client.chat_postMessage.return_value = {"ts": "999.999"}
+
+    if "app.slack.slack_events" in sys.modules:
+        del sys.modules["app.slack.slack_events"]
+    from app.slack.slack_events import process_slack_message
+
+    event = {
+        "text": "updated question",
+        "user": "U123",
+        "channel": "C123",
+        "ts": "123.123",
+        "edited": {"ts": "456.789"},
+        "thread_ts": "123.123",
+        "event_ts": "123.123",  # Required by log_query_stats
+        "channel_type": "channel",
+    }
+
+    # Patch dynamically inside the test body to avoid the module reload issue wiping the mocks
+    with patch("app.slack.slack_events._handle_modified_messages") as mock_handle_modified_messages, patch(
+        "app.slack.slack_events.get_conversation_session_data"
+    ) as mock_get_conversation_session_data, patch(
+        "app.slack.slack_events.process_formatted_bedrock_query"
+    ) as mock_process_formatted_bedrock_query, patch(
+        "app.slack.slack_events._handle_session_management"
+    ), patch(
+        "app.slack.slack_events.store_qa_pair"
+    ), patch(
+        "app.slack.slack_events.log_query_stats"
+    ):
+
+        mock_handle_modified_messages.return_value = True
+
+        mock_get_conversation_session_data.return_value = {"session_id": "session-123"}
+        mock_process_formatted_bedrock_query.return_value = ({"sessionId": "session-123"}, "AI response", [])
+
+        process_slack_message(event=event, event_id="evt123", client=mock_client)
+
+        mock_handle_modified_messages.assert_called_once()
+        mock_get_conversation_session_data.assert_called_once()
+
+        # Check it posted the "Processing..." message
+        mock_client.chat_postMessage.assert_called_once_with(channel="C123", text="Processing...", thread_ts="123.123")
+
+        mock_process_formatted_bedrock_query.assert_called_once()
+
+        # Check it updated the slack message
+        mock_client.chat_update.assert_called_once_with(
+            channel="C123",
+            ts="999.999",  # This matches the mock_client.chat_postMessage.return_value
+            text="AI response",
+            blocks=ANY,
+        )

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
@@ -866,3 +866,102 @@ def test_convert_markdown_to_slack_multiple_encoding_issues(mock_get_parameter: 
     assert "â¢" not in result
     assert "- Bullet point" in result
     assert "- another bullet" in result
+
+
+# ================================================================
+# Tests for deleted messages after message edit
+# ================================================================
+
+
+@patch("app.services.dynamo.get_state_information")
+@patch("app.services.ai_processor.process_ai_query")
+@patch("app.slack.slack_events.get_conversation_session")
+def test_process_slack_message_clears_existing_replies_on_edit(
+    mock_get_session: Mock,
+    mock_process_ai_query: Mock,
+    mock_get_state_information: Mock,
+    mock_get_parameter: Mock,
+    mock_env: Mock,
+):
+    """Test that editing a message clears previous bot replies in the thread"""
+    mock_client = Mock()
+    mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
+    mock_client.chat_update.return_value = {"ok": True}
+
+    # Mocking the returned thread dict to simulate 1 original message and 2 replies
+    mock_client.conversations_replies.return_value = {
+        "messages": [{"ts": "original_123"}, {"ts": "reply_456"}, {"ts": "reply_789"}]
+    }
+
+    mock_process_ai_query.return_value = {
+        "text": "AI response",
+        "session_id": "session-123",
+        "citations": [],
+        "kb_response": {"output": {"text": "AI response"}},
+    }
+    mock_get_session.return_value = None
+
+    if "app.slack.slack_events" in sys.modules:
+        del sys.modules["app.slack.slack_events"]
+    from app.slack.slack_events import process_slack_message
+
+    slack_event_data = {
+        "text": "<@U123> updated question",
+        "user": "U456",
+        "channel": "C789",
+        "ts": "1234567890.123",
+        "edited": {"user": "U456", "ts": "original_123"},
+    }
+
+    process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
+
+    # Assertions to ensure it fetched the thread and deleted only the replies
+    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="original_123")
+
+    assert mock_client.delete.call_count == 2
+    mock_client.delete.assert_any_call(channel="C789", ts="reply_456")
+    mock_client.delete.assert_any_call(channel="C789", ts="reply_789")
+
+
+@patch("app.services.dynamo.get_state_information")
+@patch("app.services.ai_processor.process_ai_query")
+@patch("app.slack.slack_events.get_conversation_session")
+def test_process_slack_message_no_replies_cleared_on_edit(
+    mock_get_session: Mock,
+    mock_process_ai_query: Mock,
+    mock_get_state_information: Mock,
+    mock_get_parameter: Mock,
+    mock_env: Mock,
+):
+    """Test that editing a message without replies doesn't trigger deletions"""
+    mock_client = Mock()
+    mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
+    mock_client.chat_update.return_value = {"ok": True}
+
+    # Mocking a thread that only contains the original message (no replies)
+    mock_client.conversations_replies.return_value = {"messages": [{"ts": "original_123"}]}
+
+    mock_process_ai_query.return_value = {
+        "text": "AI response",
+        "session_id": "session-123",
+        "citations": [],
+        "kb_response": {"output": {"text": "AI response"}},
+    }
+    mock_get_session.return_value = None
+
+    if "app.slack.slack_events" in sys.modules:
+        del sys.modules["app.slack.slack_events"]
+    from app.slack.slack_events import process_slack_message
+
+    slack_event_data = {
+        "text": "<@U123> updated question",
+        "user": "U456",
+        "channel": "C789",
+        "ts": "1234567890.123",
+        "edited": {"user": "U456", "ts": "original_123"},
+    }
+
+    process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
+
+    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="original_123")
+    mock_client.delete.assert_not_called()

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
@@ -885,12 +885,12 @@ def test_process_slack_message_clears_existing_replies_on_edit(
 ):
     """Test that editing a message clears previous bot replies in the thread"""
     mock_client = Mock()
-    mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
+    mock_client.chat_postMessage.return_value = {"ts": "123.124"}
     mock_client.chat_update.return_value = {"ok": True}
 
     # Mocking the returned thread dict to simulate 1 original message and 2 replies
     mock_client.conversations_replies.return_value = {
-        "messages": [{"ts": "original_123"}, {"ts": "reply_456"}, {"ts": "reply_789"}]
+        "messages": [{"ts": "997.999"}, {"ts": "998.999"}, {"ts": "999.999"}]
     }
 
     mock_process_ai_query.return_value = {
@@ -909,18 +909,21 @@ def test_process_slack_message_clears_existing_replies_on_edit(
         "text": "<@U123> updated question",
         "user": "U456",
         "channel": "C789",
-        "ts": "1234567890.123",
-        "edited": {"user": "U456", "ts": "original_123"},
+        "ts": "123.123",
+        "event_ts": "123.123",
+        "edited": {"user": "U456", "ts": "456.789"},
     }
 
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
     # Assertions to ensure it fetched the thread and deleted only the replies
-    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="1234567890.123")
+    mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="123.123")
 
-    assert mock_client.delete.call_count == 2
-    mock_client.delete.assert_any_call(channel="C789", ts="reply_456")
-    mock_client.delete.assert_any_call(channel="C789", ts="reply_789")
+    from decimal import Decimal
+
+    assert mock_client.chat_delete.call_count == 2
+    mock_client.chat_delete.assert_any_call(channel="C789", ts=Decimal("998.999"))
+    mock_client.chat_delete.assert_any_call(channel="C789", ts=Decimal("999.999"))
 
 
 @patch("app.services.dynamo.get_state_information")
@@ -964,4 +967,4 @@ def test_process_slack_message_no_replies_cleared_on_edit(
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
     mock_client.conversations_replies.assert_called_once_with(channel="C789", ts="1234567890.123")
-    mock_client.delete.assert_not_called()
+    mock_client.chat_delete.assert_not_called()


### PR DESCRIPTION
## Summary

Handles users modifying messages

### Details

1. If user modifies a message that has no later messages in the chain
   - The bot response to the message is modified
   - The old message is remove
2. If the user modified a message that has later messages
  - The bot doesn't change any responses
  - No messages are modified or deleted
  - The bot posts an ephemeral message, only visible to the user

---
# Examples:

<details>
<summary>
Changing message without any follow up messages
</summary>


**Original**:
<img width="1059" height="1099" alt="image" src="https://github.com/user-attachments/assets/757e9d22-9297-4841-a2b9-89f88afa445c" />

**Modified**:
> Only seemed to respond to the edit if I tagged `@dev-eps-assist-me`
<img width="1053" height="1019" alt="image" src="https://github.com/user-attachments/assets/14112ffd-5eb4-4e66-ae58-333c47121d40" />

</details>



<details>
<summary>
Changing message with follow up messages
</summary>


**Original**:
<img width="1053" height="1019" alt="image" src="https://github.com/user-attachments/assets/14112ffd-5eb4-4e66-ae58-333c47121d40" />

**Modified**:
> Only seemed to respond to the edit if I tagged `@dev-eps-assist-me`
<img width="1047" height="993" alt="image" src="https://github.com/user-attachments/assets/12e65c02-36b5-42a3-9878-254f5af41384" />


</summary>

