### PR TITLE
Fix: [AEA-6587] - Response Gets Stuck on "Processing..."

### DIFF
--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -506,10 +506,11 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
     try:
         user_id = event["user"]
         channel = event["channel"]
+        event_ts = event["event_ts"]
         conversation_key, thread_ts = conversation_key_and_root(event)
 
-        if channel and thread_ts:
-            message_duplication_id = f"msg_{channel}_{thread_ts}"
+        if channel and event_ts:
+            message_duplication_id = f"msg_{channel}_{event_ts}"
             if is_duplicate_event(message_duplication_id):
                 logger.info(f"Skipping overlapping app_mention/message event: {message_duplication_id}")
                 return

--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -508,6 +508,12 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
         channel = event["channel"]
         conversation_key, thread_ts = conversation_key_and_root(event)
 
+        if channel and thread_ts:
+            message_duplication_id = f"msg_{channel}_{thread_ts}"
+            if is_duplicate_event(message_duplication_id):
+                logger.info(f"Skipping overlapping app_mention/message event: {message_duplication_id}")
+                return
+
         # Remove Slack user mentions from message text
         user_query = re.sub(r"<@[UW][A-Z0-9]+(\|[^>]+)?>", "", event["text"]).strip()
 
@@ -539,24 +545,9 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
         feedback_data = {"channel": channel, "message_ts": message_ts, "thread_ts": thread_ts}
 
         # Call Bedrock to process the user query
-        try:
-            kb_response, response_text, blocks = process_formatted_bedrock_query(
-                user_query=user_query, session_id=session_id, feedback_data={**feedback_data, "ck": conversation_key}
-            )
-        except Exception as e:
-            error_code = e.response.get("Error", {}).get("Code")
-            if error_code == "ConflictException":
-                logger.warning(
-                    f"ConflictException caught for session {session_id}",
-                    extra={"event_id": event_id, "error": traceback.format_exc()},
-                )
-            client.chat_update(
-                channel=channel,
-                ts=message_ts,
-                text="An error occurred, please try again.",
-                blocks=[],
-            )
-            return
+        kb_response, response_text, blocks = process_formatted_bedrock_query(
+            user_query=user_query, session_id=session_id, feedback_data={**feedback_data, "ck": conversation_key}
+        )
 
         _handle_session_management(
             **feedback_data,
@@ -577,8 +568,7 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
                 f"Failed to update message: {e}",
                 extra={"event_id": event_id, "message_ts": message_ts, "error": traceback.format_exc()},
             )
-            log_query_stats(user_query, event, channel, client, thread_ts)
-            return
+        log_query_stats(user_query, event, channel, client, thread_ts)
     except Exception as e:
         logger.error(f"Error processing message: {e}", extra={"event_id": event_id, "error": traceback.format_exc()})
 

--- a/packages/slackBotFunction/app/slack/slack_events.py
+++ b/packages/slackBotFunction/app/slack/slack_events.py
@@ -539,9 +539,24 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
         feedback_data = {"channel": channel, "message_ts": message_ts, "thread_ts": thread_ts}
 
         # Call Bedrock to process the user query
-        kb_response, response_text, blocks = process_formatted_bedrock_query(
-            user_query=user_query, session_id=session_id, feedback_data={**feedback_data, "ck": conversation_key}
-        )
+        try:
+            kb_response, response_text, blocks = process_formatted_bedrock_query(
+                user_query=user_query, session_id=session_id, feedback_data={**feedback_data, "ck": conversation_key}
+            )
+        except Exception as e:
+            error_code = e.response.get("Error", {}).get("Code")
+            if error_code == "ConflictException":
+                logger.warning(
+                    f"ConflictException caught for session {session_id}",
+                    extra={"event_id": event_id, "error": traceback.format_exc()},
+                )
+            client.chat_update(
+                channel=channel,
+                ts=message_ts,
+                text="An error occurred, please try again.",
+                blocks=[],
+            )
+            return
 
         _handle_session_management(
             **feedback_data,
@@ -562,7 +577,8 @@ def process_slack_message(event: Dict[str, Any], event_id: str, client: WebClien
                 f"Failed to update message: {e}",
                 extra={"event_id": event_id, "message_ts": message_ts, "error": traceback.format_exc()},
             )
-        log_query_stats(user_query, event, channel, client, thread_ts)
+            log_query_stats(user_query, event, channel, client, thread_ts)
+            return
     except Exception as e:
         logger.error(f"Error processing message: {e}", extra={"event_id": event_id, "error": traceback.format_exc()})
 

--- a/packages/slackBotFunction/app/utils/handler_utils.py
+++ b/packages/slackBotFunction/app/utils/handler_utils.py
@@ -148,16 +148,6 @@ def gate_common(event: Dict[str, Any], body: Dict[str, Any]) -> str | None:
         logger.info(f"Skipping duplicate event: {event_id}")
         return None
 
-    # Check if the message is a duplicate
-    channel = event.get("channel")
-    message_ts = event.get("ts")
-    if channel and message_ts:
-        # Create a unique ID for the physical message to catch the overlap
-        msg_dupe_id = f"msg_{channel}_{message_ts}"
-        if is_duplicate_event(msg_dupe_id):
-            logger.info(f"Skipping overlapping app_mention/message event: {msg_dupe_id}")
-            return None
-
     return event_id
 
 

--- a/packages/slackBotFunction/app/utils/handler_utils.py
+++ b/packages/slackBotFunction/app/utils/handler_utils.py
@@ -148,6 +148,16 @@ def gate_common(event: Dict[str, Any], body: Dict[str, Any]) -> str | None:
         logger.info(f"Skipping duplicate event: {event_id}")
         return None
 
+    # Check if the message is a duplicate
+    channel = event.get("channel")
+    message_ts = event.get("ts")
+    if channel and message_ts:
+        # Create a unique ID for the physical message to catch the overlap
+        msg_dupe_id = f"msg_{channel}_{message_ts}"
+        if is_duplicate_event(msg_dupe_id):
+            logger.info(f"Skipping overlapping app_mention/message event: {msg_dupe_id}")
+            return None
+
     return event_id
 
 
@@ -319,7 +329,11 @@ def should_reply_to_message(event: Dict[str, Any], client: WebClient = None) -> 
     logger.debug("Checking if should reply to message", extra={"event": event, "client": client})
 
     # we don't reply to non-threaded messages in group chats
-    if event.get("channel_type") == "group" and event.get("type") == "message" and event.get("thread_ts") is None:
+    if (
+        (event.get("channel_type") == "group" or event.get("channel_type") == "channel")
+        and event.get("type") == "message"
+        and event.get("thread_ts") is None
+    ):
         return False
 
     # for channel or group threads, check if bot was mentioned anywhere in the thread history

--- a/packages/slackBotFunction/tests/test_handler_utils.py
+++ b/packages/slackBotFunction/tests/test_handler_utils.py
@@ -76,7 +76,7 @@ def test_is_latest_message_exception(mock_get_state_information: Mock):
     assert result is False
 
 
-def test_gate_common_missing_event_id(mock_env: Mock):
+def test_gate_common_missing_event_id():
     """Test _gate_common with missing event_id"""
     # setup mocks
 
@@ -95,7 +95,7 @@ def test_gate_common_missing_event_id(mock_env: Mock):
     assert result is None
 
 
-def test_gate_common_bot_message(mock_env: Mock):
+def test_gate_common_bot_message():
     """Test _gate_common with bot message"""
     # setup mocks
 
@@ -114,7 +114,7 @@ def test_gate_common_bot_message(mock_env: Mock):
     assert result is None
 
 
-def test_gate_common_subtype_message(mock_env: Mock):
+def test_gate_common_subtype_message():
     """Test _gate_common with subtype message"""
     # setup mocks
 
@@ -133,7 +133,7 @@ def test_gate_common_subtype_message(mock_env: Mock):
     assert result is None
 
 
-def test_strip_mentions_with_alias(mock_env: Mock):
+def test_strip_mentions_with_alias():
     """Test _strip_mentions with user alias"""
     # setup mocks
     # delete and import module to test
@@ -149,7 +149,7 @@ def test_strip_mentions_with_alias(mock_env: Mock):
     assert result == "hello world"
 
 
-def test_gate_common_empty_vars(mock_env: Mock):
+def test_gate_common_empty_vars():
     """Test that empty feedback doesn't crash"""
     # set up mocks
 
@@ -165,7 +165,7 @@ def test_gate_common_empty_vars(mock_env: Mock):
     assert result is None
 
 
-def test_gate_common_populated_vars(mock_env: Mock):
+def test_gate_common_populated_vars():
     """Test that empty feedback doesn't crash"""
     # set up mocks
 
@@ -181,7 +181,7 @@ def test_gate_common_populated_vars(mock_env: Mock):
     assert result is None
 
 
-def test_strip_mentions(mock_env: Mock):
+def test_strip_mentions():
     """Test that empty feedback doesn't crash"""
     # set up mocks
 
@@ -197,7 +197,7 @@ def test_strip_mentions(mock_env: Mock):
     assert result == "hello world"
 
 
-def test_extract_key_and_root(mock_env: Mock):
+def test_extract_key_and_root():
     """Test that empty feedback doesn't crash"""
     # set up mocks
 
@@ -215,10 +215,7 @@ def test_extract_key_and_root(mock_env: Mock):
     assert root == "456"
 
 
-def test_respond_with_eyes_on_success(
-    mock_env: Mock,
-    mock_get_parameter: Mock,
-):
+def test_respond_with_eyes_on_success():
     """Test that respond with eyes"""
     # set up mocks
     mock_client = Mock()
@@ -236,10 +233,7 @@ def test_respond_with_eyes_on_success(
     # just need to make sure it does not error
 
 
-def test_respond_with_eyes_on_failure(
-    mock_env: Mock,
-    mock_get_parameter: Mock,
-):
+def test_respond_with_eyes_on_failure():
     """Test that respond with eyes"""
     # set up mocks
     mock_client = Mock()
@@ -259,10 +253,7 @@ def test_respond_with_eyes_on_failure(
 
 
 @patch("app.services.dynamo.store_state_information")
-def test_is_duplicate_event_returns_true_when_conditional_check_fails(
-    mock_store_state_information: Mock,
-    mock_env: Mock,
-):
+def test_is_duplicate_event_returns_true_when_conditional_check_fails(mock_store_state_information: Mock):
     """Test duplicate event detection with conditional put"""
     # set up mocks
     error = ClientError(error_response={"Error": {"Code": "ConditionalCheckFailedException"}}, operation_name="PutItem")
@@ -304,21 +295,15 @@ def test_is_duplicate_event_client_error(
 
 @patch("app.services.dynamo.store_state_information")
 def test_is_duplicate_event_no_item(
-    mock_store_state_information: Mock,
+    mock_store_state_information: Mock,  # <-- This was missing!
     mock_env: Mock,
 ):
     """Test is_duplicate_event when no item exists (successful put)"""
-    # set up mocks
-
-    # delete and import module to test
     if "app.utils.handler_utils" in sys.modules:
         del sys.modules["app.utils.handler_utils"]
     from app.utils.handler_utils import is_duplicate_event
 
-    # perform operation
     result = is_duplicate_event("test-event")
-
-    # assertions
     assert result is False
 
 
@@ -361,7 +346,7 @@ def test_extract_pull_request_id_extracts_when_there_is_a_mention():
     assert text == "<@U123> some question"
 
 
-def test_was_bot_mentioned_in_thread_root_with_mention(mock_env: Mock):
+def test_was_bot_mentioned_in_thread_root_with_mention():
     """test that was_bot_mentioned_in_thread_root returns true when this bot is mentioned"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123ABC"}
@@ -380,7 +365,7 @@ def test_was_bot_mentioned_in_thread_root_with_mention(mock_env: Mock):
     mock_client.conversations_replies.assert_called_once_with(channel="C123", ts="1234567890.123456", inclusive=True)
 
 
-def test_was_bot_mentioned_in_thread_root_without_mention(mock_env: Mock):
+def test_was_bot_mentioned_in_thread_root_without_mention():
     """test that was_bot_mentioned_in_thread_root returns false when bot is not mentioned"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123ABC"}
@@ -398,7 +383,7 @@ def test_was_bot_mentioned_in_thread_root_without_mention(mock_env: Mock):
     assert result is False
 
 
-def test_was_bot_mentioned_in_thread_root_exception(mock_env: Mock):
+def test_was_bot_mentioned_in_thread_root_exception():
     """tes that was_bot_mentioned_in_thread_root fails open on exception"""
     mock_client = Mock()
     mock_client.conversations_replies.side_effect = Exception("API Error")
@@ -412,7 +397,7 @@ def test_was_bot_mentioned_in_thread_root_exception(mock_env: Mock):
     assert result is True
 
 
-def test_should_reply_to_message_dm(mock_env: Mock):
+def test_should_reply_to_message_dm():
     """test should_reply_to_message returns True for DMs"""
     if "app.utils.handler_utils" in sys.modules:
         del sys.modules["app.utils.handler_utils"]
@@ -424,7 +409,7 @@ def test_should_reply_to_message_dm(mock_env: Mock):
     assert result is True
 
 
-def test_should_reply_to_message_group_without_thread(mock_env: Mock):
+def test_should_reply_to_message_group_without_thread():
     """test should_reply_to_message returns False for group messages without thread"""
     if "app.utils.handler_utils" in sys.modules:
         del sys.modules["app.utils.handler_utils"]
@@ -436,7 +421,7 @@ def test_should_reply_to_message_group_without_thread(mock_env: Mock):
     assert result is False
 
 
-def test_should_reply_to_message_channel_thread_with_bot_mention(mock_env: Mock):
+def test_should_reply_to_message_channel_thread_with_bot_mention():
     """test should_reply_to_message returns True for channel thread where bot was mentioned"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123"}
@@ -455,7 +440,7 @@ def test_should_reply_to_message_channel_thread_with_bot_mention(mock_env: Mock)
     assert result is True
 
 
-def test_should_reply_to_message_channel_thread_without_bot_mention(mock_env: Mock):
+def test_should_reply_to_message_channel_thread_without_bot_mention():
     """test should_reply_to_message returns False for channel thread where bot was not mentioned"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123"}
@@ -474,7 +459,7 @@ def test_should_reply_to_message_channel_thread_without_bot_mention(mock_env: Mo
     assert result is False
 
 
-def test_should_reply_to_message_channel_thread_no_client(mock_env: Mock):
+def test_should_reply_to_message_channel_thread_no_client():
     """test should_reply_to_message fails open when no client provided"""
     # setup mocks
     if "app.utils.handler_utils" in sys.modules:
@@ -487,7 +472,7 @@ def test_should_reply_to_message_channel_thread_no_client(mock_env: Mock):
     assert result is True
 
 
-def test_was_bot_mentioned_in_thread_different_bot(mock_env: Mock):
+def test_was_bot_mentioned_in_thread_different_bot():
     """test that was_bot_mentioned_in_thread_root returns false when a different bot is mentioned"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123ABC"}
@@ -505,7 +490,7 @@ def test_was_bot_mentioned_in_thread_different_bot(mock_env: Mock):
     assert result is False
 
 
-def test_was_bot_mentioned_later_in_thread(mock_env: Mock):
+def test_was_bot_mentioned_later_in_thread():
     """test that bot mention later in thread is detected"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123ABC"}
@@ -527,7 +512,7 @@ def test_was_bot_mentioned_later_in_thread(mock_env: Mock):
     assert result is True
 
 
-def test_should_reply_to_message_group_thread_with_bot_mention(mock_env: Mock):
+def test_should_reply_to_message_group_thread_with_bot_mention():
     """test should_reply_to_message returns True for group thread where bot was mentioned"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123"}
@@ -546,7 +531,7 @@ def test_should_reply_to_message_group_thread_with_bot_mention(mock_env: Mock):
     assert result is True
 
 
-def test_should_reply_to_message_group_thread_without_bot_mention(mock_env: Mock):
+def test_should_reply_to_message_group_thread_without_bot_mention():
     """test should_reply_to_message returns False for group thread where bot was not mentioned"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123"}
@@ -565,7 +550,7 @@ def test_should_reply_to_message_group_thread_without_bot_mention(mock_env: Mock
     assert result is False
 
 
-def test_get_bot_user_id_auth_test_fails(mock_env: Mock):
+def test_get_bot_user_id_auth_test_fails():
     """test get_bot_user_id returns None when auth_test fails"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": False}
@@ -582,7 +567,7 @@ def test_get_bot_user_id_auth_test_fails(mock_env: Mock):
     assert result is None
 
 
-def test_get_bot_user_id_exception(mock_env: Mock):
+def test_get_bot_user_id_exception():
     """test get_bot_user_id returns None when exception occurs"""
     mock_client = Mock()
     mock_client.auth_test.side_effect = Exception("Auth failed")
@@ -599,7 +584,7 @@ def test_get_bot_user_id_exception(mock_env: Mock):
     assert result is None
 
 
-def test_was_bot_mentioned_no_messages_in_response(mock_env: Mock):
+def test_was_bot_mentioned_no_messages_in_response():
     """test fail when API returns no messages"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123ABC"}
@@ -614,7 +599,7 @@ def test_was_bot_mentioned_no_messages_in_response(mock_env: Mock):
     assert result is True
 
 
-def test_was_bot_mentioned_api_not_ok(mock_env: Mock):
+def test_was_bot_mentioned_api_not_ok():
     """test fail when API returns ok: False"""
     mock_client = Mock()
     mock_client.auth_test.return_value = {"ok": True, "user_id": "U123ABC"}
@@ -627,3 +612,21 @@ def test_was_bot_mentioned_api_not_ok(mock_env: Mock):
     result = was_bot_mentioned_in_thread_root("C123", "1234567890.123456", mock_client)
 
     assert result is True
+
+
+def test_should_reply_to_message_channel_without_thread():
+    """test should_reply_to_message returns False for channel messages without thread"""
+    if "app.utils.handler_utils" in sys.modules:
+        del sys.modules["app.utils.handler_utils"]
+    from app.utils.handler_utils import should_reply_to_message
+
+    event = {
+        "channel_type": "channel",
+        "type": "message",
+        "channel": "C123",
+        "ts": "123",
+        # thread_ts is intentionally omitted (None)
+    }
+    result = should_reply_to_message(event)
+
+    assert result is False

--- a/packages/slackBotFunction/tests/test_privacy_changes.py
+++ b/packages/slackBotFunction/tests/test_privacy_changes.py
@@ -22,7 +22,7 @@ def test_get_friendly_channel_name_returns_name_for_public_channel():
     assert result == "general"
 
 
-def test_log_query_stats_masks_dm_channel(mock_env, mock_get_parameter):
+def test_log_query_stats_masks_dm_channel():
     # reload module to ensure clean state and correct patching
     if "app.slack.slack_events" in sys.modules:
         del sys.modules["app.slack.slack_events"]
@@ -47,12 +47,16 @@ def test_log_query_stats_masks_dm_channel(mock_env, mock_get_parameter):
         mock_client.conversations_info.assert_not_called()
 
 
-def test_process_slack_message_log_privacy(mock_env, mock_get_parameter):
+def test_process_slack_message_log_privacy():
     if "app.slack.slack_events" in sys.modules:
         del sys.modules["app.slack.slack_events"]
 
+    if "app.utils.handler_utils" in sys.modules:
+        del sys.modules["app.utils.handler_utils"]
+
     from app.slack.slack_events import process_slack_message
     import app.slack.slack_events
+    import app.utils.handler_utils
 
     with patch.object(app.slack.slack_events, "logger") as mock_logger, patch.object(
         app.slack.slack_events, "conversation_key_and_root", return_value=("key", "ts")
@@ -60,7 +64,11 @@ def test_process_slack_message_log_privacy(mock_env, mock_get_parameter):
         app.slack.slack_events, "get_friendly_channel_name"
     ), patch.object(
         app.slack.slack_events, "process_ai_query"
-    ) as mock_process_ai:
+    ) as mock_process_ai, patch.object(
+        app.slack.slack_events, "is_duplicate_event", return_value=False
+    ), patch.object(
+        app.slack.slack_events, "store_qa_pair"
+    ):
 
         mock_client = Mock()
         mock_client.chat_postMessage.return_value = {"ts": "123"}

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_citations.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_citations.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import pytest
 from unittest.mock import Mock, MagicMock, patch
 
@@ -9,66 +8,48 @@ def mock_logger():
     return MagicMock()
 
 
-@patch("app.services.dynamo.get_state_information")
-@patch("app.services.ai_processor.process_ai_query")
-@patch("app.slack.slack_events.get_conversation_session")
 @patch("app.slack.slack_events._create_feedback_blocks")
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
+@patch("app.slack.slack_events.get_conversation_session_data", return_value=None)
+@patch("app.slack.slack_events.process_ai_query")
 def test_citation_processing(
-    mock_get_session: Mock,
     mock_process_ai_query: Mock,
+    mock_get_session: Mock,
+    mock_duplicate_event: Mock,
     mock_create_feedback_blocks: Mock,
-    mock_get_state_information: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
 ):
     """Test block builder is being called correctly"""
-    # set up mocks
-    mock_client = Mock()
-    mock_client.chat_postMessage.return_value = {"ts": ""}
-    mock_process_ai_query.return_value = {
-        "text": "AI response",
-        "session_id": "session-123",
-        "citations": [],
-        "kb_response": {"output": {"text": "AI response"}},
-    }
-    mock_get_session.return_value = None  # No existing session
-
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_slack_message
 
-    # perform operation
+    mock_client = Mock()
+    mock_client.chat_postMessage.return_value = {"ts": "123"}
+
+    mock_process_ai_query.return_value = {
+        "text": "Answer",
+        "session_id": "session-123",
+        "citations": [],
+        "kb_response": {"output": {"text": "AI response"}, "sessionId": "session-123"},
+    }
+
     slack_event_data = {
         "text": "Answer",
         "user": "U456",
-        "channel": "C789",
+        "channel": "D789",
         "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
     }
 
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-    # assertions
-    # Verify that the message was processed (process_ai_query was called)
     mock_create_feedback_blocks.assert_called_once()
 
 
-def test_process_slack_message_split_citation():
-    # set up mocks
-    mock_client = Mock()
-    mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
-    mock_client.chat_update.return_value = {"ok": True}
-
-
 def test_process_citation_events_update_chat():
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
     mock_client.chat_update.return_value = {"ok": True}
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_async_slack_action
 
     body = {
@@ -122,22 +103,15 @@ def test_process_citation_events_update_chat():
         ],
     }
 
-    # perform operation
     process_async_slack_action(body, mock_client)
-
-    # assertions
     mock_client.chat_update.assert_called()
 
 
 def test_process_citation_events_update_chat_message_open_citation():
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
     mock_client.chat_update.return_value = {"ok": True}
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import open_citation
 
     params = {
@@ -163,7 +137,7 @@ def test_process_citation_events_update_chat_message_open_citation():
                     "text": "[1] The body of the citation",
                     "emoji": "true",
                 },
-                "style": None,  # Set citation as de-active
+                "style": None,
                 "value": str(params),
             },
         ],
@@ -173,10 +147,8 @@ def test_process_citation_events_update_chat_message_open_citation():
         "blocks": [citations],
     }
 
-    # perform operation
     open_citation("ABC", "123", message, params, mock_client)
 
-    # assertions
     expected_blocks = [
         citations,
         {
@@ -190,14 +162,10 @@ def test_process_citation_events_update_chat_message_open_citation():
 
 
 def test_process_citation_events_update_chat_message_close_citation():
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
     mock_client.chat_update.return_value = {"ok": True}
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import open_citation
 
     params = {
@@ -223,7 +191,7 @@ def test_process_citation_events_update_chat_message_close_citation():
                     "text": "[1] The body of the citation",
                     "emoji": "true",
                 },
-                "style": "primary",  # Set citation as active
+                "style": "primary",
                 "value": str(params),
             },
         ],
@@ -239,10 +207,8 @@ def test_process_citation_events_update_chat_message_close_citation():
         "blocks": [citations, citation_body],
     }
 
-    # perform operation
     open_citation("ABC", "123", message, params, mock_client)
 
-    # assertions
     expected_blocks = [
         citations,
     ]
@@ -251,14 +217,10 @@ def test_process_citation_events_update_chat_message_close_citation():
 
 
 def test_process_citation_events_update_chat_message_change_close_citation():
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
     mock_client.chat_update.return_value = {"ok": True}
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import open_citation
 
     params = {
@@ -284,7 +246,7 @@ def test_process_citation_events_update_chat_message_change_close_citation():
                     "text": "[1] The body of the citation",
                     "emoji": "true",
                 },
-                "style": "primary",  # Set citation as active
+                "style": "primary",
                 "value": str(params),
             },
             {
@@ -295,7 +257,7 @@ def test_process_citation_events_update_chat_message_change_close_citation():
                     "text": "[2] The body of the citation",
                     "emoji": "true",
                 },
-                "style": None,  # Set citation as active
+                "style": None,
                 "value": str(params),
             },
         ],
@@ -317,70 +279,30 @@ def test_process_citation_events_update_chat_message_change_close_citation():
         "blocks": [citations, first_citation_body],
     }
 
-    # perform operation
     open_citation("ABC", "123", message, params, mock_client)
 
-    # assertions
     expected_blocks = [citations, second_citation_body]
     mock_client.chat_update.assert_called()
     mock_client.chat_update.assert_called_with(channel="ABC", ts="123", blocks=expected_blocks)
 
 
-def test_create_response_body_no_error_without_citations(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
+def test_create_response_body_creates_body_without_citations():
     from app.slack.slack_events import _create_response_body
 
-    # perform operation
-    _create_response_body(
-        citations=[],
-        feedback_data={},
-        response_text="This is a response without a citation.[1]",
-    )
-
-    # assertions
-    # no assertions as we are just checking it does not throw an error
-
-
-def test_create_response_body_creates_body_without_citations(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
-    from app.slack.slack_events import _create_response_body
-
-    # perform operation
     response = _create_response_body(
         citations=[],
         feedback_data={},
         response_text="This is a response without a citation.",
     )
 
-    # assertions
     assert len(response) > 0
     assert response[0]["type"] == "section"
     assert "This is a response without a citation." in response[0]["text"]["text"]
 
 
-def test_create_response_body_update_body_with_citations(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
+def test_create_response_body_update_body_with_citations():
     from app.slack.slack_events import _create_response_body
 
-    # perform operation
     response = _create_response_body(
         citations=[
             {
@@ -394,7 +316,6 @@ def test_create_response_body_update_body_with_citations(
         response_text="This is a response with a citation.[1]",
     )
 
-    # assertions
     assert len(response) > 1
     assert response[1]["type"] == "actions"
     assert response[1]["block_id"] == "citation_actions"
@@ -405,17 +326,9 @@ def test_create_response_body_update_body_with_citations(
     assert "[1] Citation Title" in citation_element["text"]["text"]
 
 
-def test_create_response_body_creates_body_with_multiple_citations(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
+def test_create_response_body_creates_body_with_multiple_citations():
     from app.slack.slack_events import _create_response_body
 
-    # perform operation
     response = _create_response_body(
         citations=[
             {
@@ -435,7 +348,6 @@ def test_create_response_body_creates_body_with_multiple_citations(
         response_text="This is a response with a citation.[1]",
     )
 
-    # assertions
     assert len(response) > 1
     assert response[1]["type"] == "actions"
     assert response[1]["block_id"] == "citation_actions"
@@ -451,17 +363,9 @@ def test_create_response_body_creates_body_with_multiple_citations(
     assert "[2] Citation Title" in second_citation_element["text"]["text"]
 
 
-def test_create_response_body_creates_body_ignoring_low_score_citations(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
+def test_create_response_body_creates_body_ignoring_low_score_citations():
     from app.slack.slack_events import _create_response_body
 
-    # perform operation
     response = _create_response_body(
         citations=[
             {
@@ -481,7 +385,6 @@ def test_create_response_body_creates_body_ignoring_low_score_citations(
         response_text="This is a response with a citation.[1]",
     )
 
-    # assertions
     assert len(response) > 1
     assert response[1]["type"] == "actions"
     assert response[1]["block_id"] == "citation_actions"
@@ -495,17 +398,9 @@ def test_create_response_body_creates_body_ignoring_low_score_citations(
     assert "[2] Citation Title" in citation_element["text"]["text"]
 
 
-def test_create_response_body_update_body_with_reformatted_citations(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
+def test_create_response_body_update_body_with_reformatted_citations():
     from app.slack.slack_events import _create_response_body
 
-    # perform operation
     response = _create_response_body(
         citations=[
             {
@@ -519,23 +414,14 @@ def test_create_response_body_update_body_with_reformatted_citations(
         response_text="This is a response with a citation.[cit_1]",
     )
 
-    # assertions
     assert len(response) > 1
     assert response[0]["type"] == "section"
     assert "This is a response with a citation.[1]" in response[0]["text"]["text"]
 
 
-def test_create_response_body_creates_body_with_markdown_formatting(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
-    """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
+def test_create_response_body_creates_body_with_markdown_formatting():
     from app.slack.slack_events import _create_response_body
 
-    # perform operation
     response = _create_response_body(
         citations=[
             {
@@ -549,7 +435,6 @@ def test_create_response_body_creates_body_with_markdown_formatting(
         response_text="This is a response with a citation.[1]",
     )
 
-    # assertions
     assert len(response) > 1
     assert response[1]["type"] == "actions"
     assert response[1]["block_id"] == "citation_actions"
@@ -560,55 +445,50 @@ def test_create_response_body_creates_body_with_markdown_formatting(
     assert "*Bold*, _italics_, and `code`." in citation_value.get("body")
 
 
-@patch("app.services.ai_processor.process_ai_query")
+@patch("app.slack.slack_events.logger")
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
+@patch("app.slack.slack_events.get_conversation_session_data", return_value={})
+@patch("app.slack.slack_events.process_ai_query")
 def test_create_citation_logs_citations(
     mock_process_ai_query: Mock,
-    mock_logger,
+    mock_get_conversation_session_data: Mock,
+    mock_is_duplicate_event: Mock,
+    mock_logger: Mock,
 ):
-    with patch("app.core.config.get_logger", return_value=mock_logger):
-        # set up mocks
-        mock_client = Mock()
-        mock_client.chat_postMessage.return_value = {"ts": ""}
-        raw_citation = "1||This is the Title||This is the excerpt/ citation||0.99"
-        mock_process_ai_query.return_value = {
-            "text": "AI response" + "------" + f"<cit>{raw_citation}</cit>",
-            "session_id": "session-123",
-            "citations": [],
-            "kb_response": {"output": {"text": "AI response"}},
-        }
+    mock_client = Mock()
+    mock_client.chat_postMessage.return_value = {"ts": ""}
+    raw_citation = "1||This is the Title||This is the excerpt/ citation||0.99"
+    mock_process_ai_query.return_value = {
+        "text": "AI response" + "------" + f"<cit>{raw_citation}</cit>",
+        "session_id": "session-123",
+        "citations": [],
+        "kb_response": {"output": {"text": "AI response"}, "sessionId": "session-123"},
+    }
 
-        # delete and import module to test
-        if "app.slack.slack_events" in sys.modules:
-            del sys.modules["app.slack.slack_events"]
-        from app.slack.slack_events import process_slack_message
+    from app.slack.slack_events import process_slack_message
 
-        # perform operation
-        slack_event_data = {
-            "text": "Answer",
-            "user": "U456",
-            "channel": "C789",
-            "ts": "1234567890.123",
-        }
+    slack_event_data = {
+        "text": "Answer",
+        "user": "U456",
+        "channel": "D789",
+        "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
+    }
 
-        process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
+    process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-        # mock_logger.assert_has_calls([call.info("Found citation(s)", extra={"Raw Citations": [raw_citation]})])
-        # assertions
-
-        mock_logger.info.assert_any_call(
-            "Found citation(s)", extra={"Raw Citations": ["1||This is the Title||This is the excerpt/ citation||0.99"]}
-        )
-        mock_logger.info.assert_any_call(
-            "Parsed citation(s)",
-            extra={
-                "citations": [
-                    {
-                        "source_number": "1",
-                        "title": "This is the Title",
-                        "excerpt": "This is the excerpt/ citation",
-                        "relevance_score": "0.99",
-                    }
-                ]
-            },
-        )
-        # mock_logger.info.assert_called_with("Found citation(s)", extra={"Raw Citations": [raw_citation]})
+    mock_logger.info.assert_any_call("Found citation(s)", extra={"Raw Citations": [raw_citation]})
+    mock_logger.info.assert_any_call(
+        "Parsed citation(s)",
+        extra={
+            "citations": [
+                {
+                    "source_number": "1",
+                    "title": "This is the Title",
+                    "excerpt": "This is the excerpt/ citation",
+                    "relevance_score": "0.99",
+                }
+            ]
+        },
+    )

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
@@ -796,3 +796,60 @@ def test_should_reply_to_message_accepts_dm_message():
     result = should_reply_to_message(event)
 
     assert result is True
+
+
+@patch("app.slack.slack_events.is_duplicate_event")
+@patch("app.slack.slack_events.logger")
+def test_process_slack_message_duplicate_msg_id(mock_logger: Mock, mock_is_duplicate_event: Mock):
+    """Test that overlapping app_mention/message events are skipped"""
+    from app.slack.slack_events import process_slack_message
+
+    # Setup
+    mock_client = Mock()
+    mock_is_duplicate_event.return_value = True  # Simulate a duplicate event
+
+    event = {
+        "user": "U123",
+        "channel": "C123",
+        "event_ts": "1234567890.123",
+        "ts": "1234567890.123",
+        "text": "test question",
+        "channel_type": "channel",
+    }
+
+    # Execute
+    process_slack_message(event=event, event_id="evt123", client=mock_client)
+
+    # Assertions
+    mock_is_duplicate_event.assert_called_with("msg_C123_1234567890.123")
+    mock_logger.info.assert_called_with("Skipping overlapping app_mention/message event: msg_C123_1234567890.123")
+    mock_client.chat_postMessage.assert_not_called()  # Ensure it returns early
+
+
+@patch("app.slack.slack_events.is_duplicate_event")
+@patch("app.slack.slack_events.logger")
+def test_process_slack_message_overlapping_event(mock_logger: Mock, mock_is_duplicate_event: Mock):
+    """Test that overlapping app_mention/message events are skipped"""
+    from app.slack.slack_events import process_slack_message
+
+    mock_client = Mock()
+    # Simulate that this message was already processed
+    mock_is_duplicate_event.return_value = True
+
+    event = {
+        "user": "U123",
+        "channel": "C123",
+        "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "text": "test question",
+        "channel_type": "channel",
+    }
+
+    process_slack_message(event=event, event_id="evt123", client=mock_client)
+
+    # Assert the new logic from the PR is triggered
+    mock_is_duplicate_event.assert_called_with("msg_C123_1234567890.123")
+    mock_logger.info.assert_called_with("Skipping overlapping app_mention/message event: msg_C123_1234567890.123")
+
+    # Ensure execution returns early before calling Bedrock or Slack
+    mock_client.chat_postMessage.assert_not_called()

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
@@ -1,6 +1,7 @@
 import sys
 import pytest
 from unittest.mock import Mock, patch, MagicMock
+from botocore.exceptions import ClientError
 
 
 @pytest.fixture
@@ -866,3 +867,108 @@ def test_convert_markdown_to_slack_multiple_encoding_issues(mock_get_parameter: 
     assert "â¢" not in result
     assert "- Bullet point" in result
     assert "- another bullet" in result
+
+
+# ================================================================
+# Tests for duplicate message handling
+# ================================================================
+
+
+@patch("app.slack.slack_events.get_conversation_session_data")
+@patch("app.slack.slack_events.process_formatted_bedrock_query")
+def test_process_slack_message_handles_conflict_exception(mock_env: Mock, mock_get_parameter: Mock):
+    """
+    GIVEN the bot has posted a 'Processing...' placeholder
+    WHEN Bedrock throws a ConflictException due to a race condition on the session ID
+    THEN the placeholder should be cleared/updated with a friendly error
+    AND the bot does not stay stuck in 'Processing...'
+    """
+    mock_client = Mock()
+    mock_client.chat_postMessage.return_value = {"ts": "placeholder_ts_123"}
+
+    # Reload module to ensure clean state BEFORE patching
+    if "app.slack.slack_events" in sys.modules:
+        del sys.modules["app.slack.slack_events"]
+    from app.slack.slack_events import process_slack_message
+
+    with patch("app.slack.slack_events.process_formatted_bedrock_query") as mock_process_bedrock:
+
+        # Simulate the Bedrock race condition ConflictException
+        error_response = {"Error": {"Code": "ConflictException", "Message": "Session is currently being used"}}
+        mock_process_bedrock.side_effect = ClientError(error_response, "RetrieveAndGenerate")
+
+        event = {
+            "text": "<@U123> test question",
+            "user": "U456",
+            "channel": "C789",
+            "ts": "1234567890.123",
+            "event_ts": "123",
+            "channel_type": "channel",
+        }
+
+        process_slack_message(event=event, event_id="evt123", client=mock_client)
+
+        mock_client.chat_postMessage.assert_called_once_with(
+            channel="C789", text="Processing...", thread_ts="1234567890.123"
+        )
+
+        mock_client.chat_update.assert_called_once_with(
+            channel="C789", ts="placeholder_ts_123", text="An error occurred, please try again.", blocks=[]
+        )
+
+
+def test_should_reply_to_message_rejects_raw_message_in_public_channel(mock_env: Mock):
+    """
+    GIVEN the bot is installed in a public channel
+    WHEN a user @mentions the bot, firing a duplicate 'message' event alongside 'app_mention'
+    THEN the 'message' event should be dropped to prevent a ConflictException race condition
+    """
+    import sys
+
+    if "app.utils.handler_utils" in sys.modules:
+        del sys.modules["app.utils.handler_utils"]
+    from app.utils.handler_utils import should_reply_to_message
+
+    event = {"channel_type": "channel", "type": "message", "channel": "C123", "ts": "123"}
+
+    result = should_reply_to_message(event)
+
+    assert result is False
+
+
+def test_should_reply_to_message_accepts_app_mention_in_public_channel(mock_env: Mock):
+    """
+    GIVEN the bot is installed in a public channel
+    WHEN a user @mentions the bot, firing the 'app_mention' event
+    THEN the event should proceed normally without being blocked
+    """
+    import sys
+
+    if "app.utils.handler_utils" in sys.modules:
+        del sys.modules["app.utils.handler_utils"]
+    from app.utils.handler_utils import should_reply_to_message
+
+    event = {"channel_type": "channel", "type": "app_mention", "channel": "C123", "ts": "123"}
+
+    result = should_reply_to_message(event)
+
+    assert result is True
+
+
+def test_should_reply_to_message_accepts_dm_message(mock_env: Mock):
+    """
+    GIVEN the bot is installed
+    WHEN a user DMs the bot with a prompt (which only fires a 'message' event)
+    THEN the event should proceed normally without being blocked
+    """
+    import sys
+
+    if "app.utils.handler_utils" in sys.modules:
+        del sys.modules["app.utils.handler_utils"]
+    from app.utils.handler_utils import should_reply_to_message
+
+    event = {"channel_type": "im", "type": "message", "channel": "D123", "ts": "123"}
+
+    result = should_reply_to_message(event)
+
+    assert result is True

--- a/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
+++ b/packages/slackBotFunction/tests/test_slack_events/test_slack_events_messages.py
@@ -1,7 +1,6 @@
-import sys
 import pytest
 from unittest.mock import Mock, patch, MagicMock
-from botocore.exceptions import ClientError
+from app.core.config import bot_messages
 
 
 @pytest.fixture
@@ -9,61 +8,56 @@ def mock_logger():
     return MagicMock()
 
 
-@patch("app.utils.handler_utils.forward_to_pull_request_lambda")
+@patch("app.slack.slack_events.forward_to_pull_request_lambda")
 def test_process_async_slack_event_normal_message(
-    mock_forward_to_pull_request_lambda: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
+    mock_forward_events: Mock,
 ):
     """Test successful async event processing"""
-    # set up mocks
     mock_client = Mock()
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_async_slack_event
 
-    # perform operation
-    slack_event_data = {"text": "<@U123> test question", "user": "U456", "channel": "C789", "ts": "1234567890.123"}
+    slack_event_data = {
+        "text": "<@U123> test question",
+        "user": "U456",
+        "channel": "D789",
+        "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
+    }
     with patch("app.slack.slack_events.process_feedback_event") as mock_process_feedback_event, patch(
         "app.slack.slack_events.process_slack_message"
     ) as mock_process_slack_message:
         process_async_slack_event(event=slack_event_data, event_id="evt123", client=mock_client)
-        mock_forward_to_pull_request_lambda.assert_not_called()
+        mock_forward_events.assert_not_called()
         mock_process_feedback_event.assert_not_called()
         mock_process_slack_message.assert_called_once_with(
             event=slack_event_data, event_id="evt123", client=mock_client
         )
 
 
-@patch("app.utils.handler_utils.forward_to_pull_request_lambda")
+@patch("app.slack.slack_events.forward_to_pull_request_lambda")
 def test_process_async_slack_event_pull_request_with_mention(
-    mock_forward_to_pull_request_lambda: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
+    mock_forward_events: Mock,
 ):
     """Test successful async event processing"""
-    # set up mocks
     mock_client = Mock()
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_async_slack_event
 
-    # perform operation
     slack_event_data = {
         "text": "<@U123> pr: 123 test question",
         "user": "U456",
         "channel": "C789",
         "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "channel",
     }
     with patch("app.slack.slack_events.process_feedback_event") as mock_process_feedback_event, patch(
         "app.slack.slack_events.process_slack_message"
     ) as mock_process_slack_message:
         process_async_slack_event(event=slack_event_data, event_id="evt123", client=mock_client)
-        mock_forward_to_pull_request_lambda.assert_called_once_with(
+        mock_forward_events.assert_called_once_with(
             body={},
             pull_request_id="123",
             event=slack_event_data,
@@ -75,33 +69,28 @@ def test_process_async_slack_event_pull_request_with_mention(
         mock_process_slack_message.assert_not_called()
 
 
-@patch("app.utils.handler_utils.forward_to_pull_request_lambda")
+@patch("app.slack.slack_events.forward_to_pull_request_lambda")
 def test_process_async_slack_event_pull_request_with_no_mention(
-    mock_forward_to_pull_request_lambda: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
+    mock_forward_events: Mock,
 ):
     """Test successful async event processing"""
-    # set up mocks
     mock_client = Mock()
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_async_slack_event
 
-    # perform operation
     slack_event_data = {
         "text": "pr: 123 test question",
         "user": "U456",
         "channel": "C789",
         "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "channel",
     }
     with patch("app.slack.slack_events.process_feedback_event") as mock_process_feedback_event, patch(
         "app.slack.slack_events.process_slack_message"
     ) as mock_process_slack_message:
         process_async_slack_event(event=slack_event_data, event_id="evt123", client=mock_client)
-        mock_forward_to_pull_request_lambda.assert_called_once_with(
+        mock_forward_events.assert_called_once_with(
             body={},
             pull_request_id="123",
             event=slack_event_data,
@@ -113,45 +102,35 @@ def test_process_async_slack_event_pull_request_with_no_mention(
         mock_process_slack_message.assert_not_called()
 
 
-def test_process_slack_message_empty_query(mock_get_parameter: Mock, mock_env: Mock):
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
+def test_process_slack_message_empty_query(mock_is_duplicate_event: Mock):
     """Test async event processing with empty query"""
-    # set up mocks
     mock_client = Mock()
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_slack_message
 
-    # perform operation
     slack_event_data = {
-        "text": "<@U123>",  # Only mention, no actual query
+        "text": "<@U123>",
         "user": "U456",
-        "channel": "C789",
+        "channel": "D789",
         "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
     }
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-    # assertions
     mock_client.chat_postMessage.assert_called_once_with(
-        channel="C789",
-        text="Hi there! Please ask me a question and I'll help you find information from our knowledge base.",
-        thread_ts="1234567890.123",
+        channel="D789", text=bot_messages.EMPTY_QUERY, thread_ts="1234567890.123"
     )
 
 
-@patch("app.services.dynamo.get_state_information")
-@patch("app.services.ai_processor.process_ai_query")
-@patch("app.slack.slack_events.get_conversation_session")
+@patch("app.slack.slack_events.process_ai_query")
+@patch("app.slack.slack_events.get_conversation_session_data", return_value={})
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
 def test_process_slack_message_with_thread_ts(
-    mock_get_session: Mock,
-    mock_process_ai_query: Mock,
-    mock_get_state_information: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
+    mock_is_duplicate_event: Mock, mock_get_session: Mock, mock_process_ai_query: Mock
 ):
     """Test async event processing with existing thread_ts"""
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
     mock_client.chat_update.return_value = {"ok": True}
@@ -161,82 +140,66 @@ def test_process_slack_message_with_thread_ts(
         "citations": [],
         "kb_response": {"output": {"text": "AI response"}},
     }
-    mock_get_session.return_value = None  # No existing session
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
-        from app.slack.slack_events import process_slack_message
+    from app.slack.slack_events import process_slack_message
 
-    # perform operation
     slack_event_data = {
         "text": "<@U123> test question",
         "user": "U456",
         "channel": "C789",
         "ts": "1234567890.123",
-        "thread_ts": "1234567888.111",  # Existing thread
+        "event_ts": "1234567890.123",
+        "channel_type": "channel",
+        "thread_ts": "1234567888.111",
     }
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-    # assertions
-    # Should be called at least once with the correct thread_ts
     assert mock_client.chat_postMessage.call_count >= 1
     first_call = mock_client.chat_postMessage.call_args_list[0]
     assert first_call[1]["thread_ts"] == "1234567888.111"
     assert first_call[1]["text"] == "Processing..."
 
 
-@patch("app.services.dynamo.get_state_information")
-@patch("app.services.ai_processor.process_ai_query")
-@patch("app.slack.slack_events.get_conversation_session")
-def test_regex_text_processing(
-    mock_get_session: Mock,
-    mock_process_ai_query: Mock,
-    mock_get_state_information: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
+@patch("app.slack.slack_events.process_ai_query")
+@patch("app.slack.slack_events.get_conversation_session_data", return_value={})
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
+def test_regex_text_processing(mock_is_duplicate_event: Mock, mock_get_session: Mock, mock_process_ai_query: Mock):
     """Test regex text processing functionality within process_async_slack_event"""
-    # set up mocks
     mock_client = Mock()
-    mock_client.chat_postMessage.return_value = {"ts": ""}
+    mock_client.chat_postMessage.return_value = {"ts": "123"}
     mock_process_ai_query.return_value = {
         "text": "AI response",
         "session_id": "session-123",
         "citations": [],
         "kb_response": {"output": {"text": "AI response"}},
     }
-    mock_get_session.return_value = None  # No existing session
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_slack_message
 
-    # perform operation
-    slack_event_data = {"text": "<@U123456> test question", "user": "U456", "channel": "C789", "ts": "1234567890.123"}
+    slack_event_data = {
+        "text": "<@U123456> test question",
+        "user": "U456",
+        "channel": "D789",
+        "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
+    }
 
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-    # assertions
-    # Verify that the message was processed (process_ai_query was called)
     mock_process_ai_query.assert_called_once()
-    # The actual regex processing happens inside the function
     assert mock_client.chat_postMessage.called
 
 
-@patch("app.services.dynamo.get_state_information")
-@patch("app.services.dynamo.store_state_information")
-@patch("app.services.ai_processor.process_ai_query")
+@patch("app.slack.slack_events.store_state_information")
+@patch("app.slack.slack_events.process_ai_query")
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
 def test_process_slack_message_with_session_storage(
+    mock_is_duplicate_event: Mock,
     mock_process_ai_query: Mock,
     mock_store_state_information: Mock,
-    mock_get_state_information: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
 ):
     """Test async event processing that stores a new session"""
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
     mock_client.chat_update.return_value = {"ok": True}
@@ -248,39 +211,29 @@ def test_process_slack_message_with_session_storage(
         "kb_response": {"output": {"text": "AI response"}, "sessionId": "new-session-123"},
     }
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_slack_message
 
-    # perform operation
     slack_event_data = {
         "text": "test question",
         "user": "U456",
-        "channel": "C789",
+        "channel": "D789",
         "ts": "1234567890.123",
-        "event_ts": "123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
     }
 
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-    # assertions
-    # Verify session was stored - should be called twice (Q&A pair + session)
     assert mock_store_state_information.call_count >= 1
 
 
-@patch("app.services.dynamo.get_state_information")
-@patch("app.services.ai_processor.process_ai_query")
-@patch("app.slack.slack_events.get_conversation_session")
+@patch("app.slack.slack_events.process_ai_query")
+@patch("app.slack.slack_events.get_conversation_session_data", return_value={})
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
 def test_process_slack_message_chat_update_no_error(
-    mock_get_session: Mock,
-    mock_process_ai_query: Mock,
-    mock_get_state_information: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
+    mock_is_duplicate_event: Mock, mock_get_session: Mock, mock_process_ai_query: Mock
 ):
     """Test process_async_slack_event with chat_update error"""
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
     mock_client.chat_update.side_effect = Exception("Update failed")
@@ -290,37 +243,31 @@ def test_process_slack_message_chat_update_no_error(
         "citations": [],
         "kb_response": {"output": {"text": "AI response"}},
     }
-    mock_get_session.return_value = None  # No existing session
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_slack_message
 
-    # perform operation
-    slack_event_data = {"text": "<@U123> test question", "user": "U456", "channel": "C789", "ts": "1234567890.123"}
+    slack_event_data = {
+        "text": "<@U123> test question",
+        "user": "U456",
+        "channel": "D789",
+        "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
+    }
     process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-    # assertions
-    # no assertions as we are just checking it does not throw an error
 
-
-@patch("app.slack.slack_events.get_conversation_session")
-@patch("app.slack.slack_events.get_conversation_session_data")
-@patch("app.slack.slack_events.cleanup_previous_unfeedback_qa")
-@patch("app.slack.slack_events.update_session_latest_message")
-@patch("app.services.ai_processor.process_ai_query")
+@patch("app.slack.slack_events.update_state_information")
+@patch("app.slack.slack_events.get_conversation_session_data", return_value={"session_id": "session-123"})
+@patch("app.slack.slack_events.process_ai_query")
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
 def test_process_slack_message_chat_update_cleanup(
+    mock_is_duplicate_event: Mock,
     mock_process_ai_query: Mock,
-    mock_update_session_latest_message: Mock,
-    mock_cleanup_previous_unfeedback_qa: Mock,
     mock_get_conversation_session_data: Mock,
-    mock_get_session: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
+    mock_update_state_information: Mock,
 ):
     """Test process_async_slack_event with chat_update error"""
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "1234567890.124"}
     mock_client.chat_update.side_effect = Exception("Update failed")
@@ -330,35 +277,29 @@ def test_process_slack_message_chat_update_cleanup(
         "citations": [],
         "kb_response": {"output": {"text": "AI response"}},
     }
-    mock_get_conversation_session_data.return_value = {"session_id": "session-123"}
-    mock_get_session.return_value = None  # No existing session
-    mock_cleanup_previous_unfeedback_qa.return_value = {"test": "123"}
 
-    # delete and import module to test
     from app.slack.slack_events import process_slack_message
 
-    # perform operation
-    slack_event_data = {"text": "<@U123> test question", "user": "U456", "channel": "C789", "ts": "1234567890.123"}
-    with patch("app.slack.slack_events.get_conversation_session_data", mock_get_conversation_session_data):
-        process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
+    slack_event_data = {
+        "text": "<@U123> test question",
+        "user": "U456",
+        "channel": "D789",
+        "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
+    }
+    process_slack_message(event=slack_event_data, event_id="evt123", client=mock_client)
 
-        # assertions
-        mock_cleanup_previous_unfeedback_qa.assert_called_once()
-        mock_update_session_latest_message.assert_called_once()
+    mock_update_state_information.assert_called_once()
 
 
-@patch("app.services.dynamo.get_state_information")
-@patch("app.services.ai_processor.process_ai_query")
-@patch("app.slack.slack_events.get_conversation_session")
+@patch("app.slack.slack_events.process_ai_query")
+@patch("app.slack.slack_events.get_conversation_session_data", return_value={})
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
 def test_process_slack_message_dm_context(
-    mock_get_session: Mock,
-    mock_process_ai_query: Mock,
-    mock_get_state_information: Mock,
-    mock_get_parameter: Mock,
-    mock_env: Mock,
+    mock_is_duplicate_event: Mock, mock_get_session: Mock, mock_process_ai_query: Mock
 ):
     """Test process_async_slack_event with DM context"""
-    # set up mocks
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "123"}
     mock_process_ai_query.return_value = {
@@ -367,28 +308,23 @@ def test_process_slack_message_dm_context(
         "citations": [],
         "kb_response": {"output": {"text": "AI response"}, "sessionId": "new-session"},
     }
-    mock_get_session.return_value = None
 
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_async_slack_event
 
-    # perform operation
     slack_event_data = {
         "text": "test question",
         "user": "U456",
         "channel": "D789",
         "ts": "123",
-        "channel_type": "im",  # DM context
+        "event_ts": "123",
+        "channel_type": "im",
     }
-    process_async_slack_event(event=slack_event_data, event_id="evt123", client=mock_client)
+    with patch("app.slack.slack_events.process_slack_message") as mock_process_slack_message:
+        process_async_slack_event(event=slack_event_data, event_id="evt123", client=mock_client)
+        mock_process_slack_message.assert_called_once()
 
-    # assertions
-    # no assertions as we are just checking it does not throw an error
 
-
-@patch("app.services.dynamo.delete_state_information")
+@patch("app.slack.slack_events.delete_state_information")
 def test_cleanup_previous_unfeedback_qa_no_previous_message(
     mock_delete_state_information: Mock,
 ):
@@ -397,118 +333,75 @@ def test_cleanup_previous_unfeedback_qa_no_previous_message(
     current_message_ts = "1234567890.124"
     session_data = {}
 
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import cleanup_previous_unfeedback_qa
 
-    # perform operation
     cleanup_previous_unfeedback_qa(conversation_key, current_message_ts, session_data)
-
-    # assertions
     mock_delete_state_information.assert_not_called()
 
 
-@patch("app.services.dynamo.delete_state_information")
+@patch("app.slack.slack_events.delete_state_information")
 def test_cleanup_previous_unfeedback_qa_same_message(
     mock_delete_state_information: Mock,
 ):
     """Test cleanup skipped when previous message is same as current"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
-
     conversation_key = "conv-123"
     current_message_ts = "1234567890.123"
     session_data = {"latest_message_ts": "1234567890.123"}
 
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import cleanup_previous_unfeedback_qa
 
-    # perform operation
     cleanup_previous_unfeedback_qa(conversation_key, current_message_ts, session_data)
-
-    # assertions
     mock_delete_state_information.assert_not_called()
 
 
-def test_create_response_body_creates_body_with_markdown_formatting(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
+def test_create_response_body_creates_body_with_markdown_formatting():
     """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_response_body
 
-    # perform operation
     response = _create_response_body(
         citations=[],
         feedback_data={},
         response_text="**Bold**, __italics__, and `code`.",
     )
 
-    # assertions
     assert len(response) > 0
     assert response[0]["type"] == "section"
-
     response_value = response[0]["text"]["text"]
-
     assert "*Bold*, _italics_, and `code`." in response_value
 
 
-def test_create_response_body_creates_body_with_lists(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
+def test_create_response_body_creates_body_with_lists():
     """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_response_body
 
     dirty_input = "Header text - Standard Dash -No Space Dash • Standard Bullet  -DoubleSpace-NoSpace"
 
-    # perform operation
     response = _create_response_body(
         citations=[],
         feedback_data={},
         response_text=dirty_input,
     )
 
-    # assertions
     assert len(response) > 0
     assert response[0]["type"] == "section"
-
     response_value = response[0]["text"]["text"]
-
     expected_output = "Header text - Standard Dash -No Space Dash - Standard Bullet  -DoubleSpace-NoSpace"
     assert expected_output in response_value
 
 
-def test_create_response_body_creates_body_without_encoding_errors(
-    mock_get_parameter: Mock,
-    mock_env: Mock,
-):
+def test_create_response_body_creates_body_without_encoding_errors():
     """Test regex text processing functionality within process_async_slack_event"""
-    # delete and import module to test
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_response_body
 
-    # perform operation
     response = _create_response_body(
         citations=[],
         feedback_data={},
         response_text="» Tabbing Issue. â¢ Bullet point issue.",
     )
 
-    # assertions
     assert len(response) > 0
     assert response[0]["type"] == "section"
-
     response_value = response[0]["text"]["text"]
-
     assert "Tabbing Issue. - Bullet point issue." in response_value
 
 
@@ -517,10 +410,8 @@ def test_create_response_body_creates_body_without_encoding_errors(
 # ================================================================
 
 
-def test_create_citation_high_relevance_score(mock_get_parameter: Mock, mock_env: Mock):
+def test_create_citation_high_relevance_score():
     """Test citation creation with high relevance score"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_citation
 
     citation = {
@@ -542,17 +433,15 @@ def test_create_citation_high_relevance_score(mock_get_parameter: Mock, mock_env
     assert result["response_text"] == "Response with [1] citation"
 
 
-def test_create_citation_low_relevance_score(mock_get_parameter: Mock, mock_env: Mock):
+def test_create_citation_low_relevance_score():
     """Test citation is skipped when relevance score is low"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_citation
 
     citation = {
         "source_number": "2",
         "title": "Low Relevance Doc",
         "excerpt": "This is low relevance",
-        "relevance_score": "0.5",  # Below 0.6 threshold
+        "relevance_score": "0.5",
     }
     feedback_data = {"ck": "conv-123"}
     response_text = "Response with [cit_2]"
@@ -563,10 +452,8 @@ def test_create_citation_low_relevance_score(mock_get_parameter: Mock, mock_env:
     assert result["response_text"] == "Response with [cit_2]"
 
 
-def test_create_citation_missing_excerpt(mock_get_parameter: Mock, mock_env: Mock):
+def test_create_citation_missing_excerpt():
     """Test citation with missing excerpt uses default message"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_citation
 
     citation = {
@@ -586,10 +473,8 @@ def test_create_citation_missing_excerpt(mock_get_parameter: Mock, mock_env: Moc
     assert button_data["body"] == "No document excerpt available."
 
 
-def test_create_citation_missing_title_uses_filename(mock_get_parameter: Mock, mock_env: Mock):
+def test_create_citation_missing_title_uses_filename():
     """Test citation uses filename when title is missing"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_citation
 
     citation = {
@@ -607,10 +492,8 @@ def test_create_citation_missing_title_uses_filename(mock_get_parameter: Mock, m
     assert result["action_buttons"][0]["text"]["text"] == "[4] document.pdf"
 
 
-def test_create_citation_fallback_source_when_missing(mock_get_parameter: Mock, mock_env: Mock):
+def test_create_citation_fallback_source_when_missing():
     """Test citation uses 'Source' when both title and filename are missing"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_citation
 
     citation = {
@@ -627,13 +510,11 @@ def test_create_citation_fallback_source_when_missing(mock_get_parameter: Mock, 
     assert result["action_buttons"][0]["text"]["text"] == "[5] Source"
 
 
-def test_create_citation_button_text_truncation(mock_get_parameter: Mock, mock_env: Mock):
+def test_create_citation_button_text_truncation():
     """Test citation button text is truncated when exceeds 75 characters"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_citation
 
-    long_title = "A" * 80  # Title longer than 75 chars
+    long_title = "A" * 80
     citation = {
         "source_number": "6",
         "title": long_title,
@@ -646,14 +527,12 @@ def test_create_citation_button_text_truncation(mock_get_parameter: Mock, mock_e
     result = _create_citation(citation, feedback_data, response_text)
 
     button_text = result["action_buttons"][0]["text"]["text"]
-    assert len(button_text) <= 77  # "[X] " + 70 chars + "..."
+    assert len(button_text) <= 77
     assert button_text.endswith("...")
 
 
-def test_create_citation_removes_newlines_from_source_number(mock_get_parameter: Mock, mock_env: Mock):
+def test_create_citation_removes_newlines_from_source_number():
     """Test citation removes newlines from source number"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_citation
 
     citation = {
@@ -671,10 +550,8 @@ def test_create_citation_removes_newlines_from_source_number(mock_get_parameter:
     assert result["action_buttons"][0]["action_id"] == "cite_7"
 
 
-def test_create_citation_zero_relevance_score(mock_get_parameter: Mock, mock_env: Mock):
+def test_create_citation_zero_relevance_score():
     """Test citation with zero relevance score is skipped"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import _create_citation
 
     citation = {
@@ -696,46 +573,35 @@ def test_create_citation_zero_relevance_score(mock_get_parameter: Mock, mock_env
 # ================================================================
 
 
-def test_convert_markdown_to_slack_bold_formatting(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_bold_formatting():
     """Test conversion of markdown bold to Slack formatting"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     markdown_text = "This is **bold text** in markdown"
     result = convert_markdown_to_slack(markdown_text)
-
     assert "*bold text*" in result
 
 
-def test_convert_markdown_to_slack_italic_formatting(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_italic_formatting():
     """Test conversion of markdown italics to Slack formatting"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     markdown_text = "This is __italic text__ in markdown"
     result = convert_markdown_to_slack(markdown_text)
-
     assert "_italic text_" in result
 
 
-def test_convert_markdown_to_slack_links(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_links():
     """Test conversion of markdown links to Slack formatting"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     markdown_text = "Check out [this link](https://example.com)"
     result = convert_markdown_to_slack(markdown_text)
-
     assert "<https://example.com|this link>" in result
 
 
-def test_convert_markdown_to_slack_encoding_issues_arrow(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_encoding_issues_arrow():
     """Test conversion removes arrow encoding issues"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text_with_encoding = "» Tab issue"
@@ -745,10 +611,8 @@ def test_convert_markdown_to_slack_encoding_issues_arrow(mock_get_parameter: Moc
     assert "Tab issue" in result
 
 
-def test_convert_markdown_to_slack_encoding_issues_bullet(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_encoding_issues_bullet():
     """Test conversion fixes bullet point encoding issues"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text_with_encoding = "â¢ Bullet point"
@@ -758,32 +622,24 @@ def test_convert_markdown_to_slack_encoding_issues_bullet(mock_get_parameter: Mo
     assert "- Bullet point" in result
 
 
-def test_convert_markdown_to_slack_empty_string(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_empty_string():
     """Test conversion of empty string"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     result = convert_markdown_to_slack("")
-
     assert result == ""
 
 
-def test_convert_markdown_to_slack_none_string(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_none_string():
     """Test conversion of None string"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     result = convert_markdown_to_slack(None)
-
     assert result == ""
 
 
-def test_convert_markdown_to_slack_combined_formatting(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_combined_formatting():
     """Test conversion with multiple formatting types"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text = "Check **bold** and __italic__ with [link](https://test.com)"
@@ -794,70 +650,53 @@ def test_convert_markdown_to_slack_combined_formatting(mock_get_parameter: Mock,
     assert "<https://test.com|link>" in result
 
 
-def test_convert_markdown_to_slack_link_with_newlines_no_space(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_link_with_newlines_no_space():
     """Test link conversion removes newlines from link text"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text = "Check [link\ntext](https://example.com)"
     result = convert_markdown_to_slack(text)
-
     assert "<https://example.com|link text>" in result
 
 
-def test_convert_markdown_to_slack_link_with_newlines_with_space(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_link_with_newlines_with_space():
     """Test link conversion removes newlines from link text"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text = "Check [link \n text](https://example.com)"
     result = convert_markdown_to_slack(text)
-
     assert "<https://example.com|link   text>" in result
 
 
-def test_convert_markdown_to_slack_link_with_newlines_with_dash(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_link_with_newlines_with_dash():
     """Test link conversion removes newlines from link text"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text = "Check [link-text](https://example.com)"
     result = convert_markdown_to_slack(text)
-
     assert "<https://example.com|link-text>" in result
 
 
-def test_convert_markdown_to_slack_link_with_newlines_with_dash_and_space(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_link_with_newlines_with_dash_and_space():
     """Test link conversion removes newlines from link text"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text = "Check [link - text](https://example.com)"
     result = convert_markdown_to_slack(text)
-
     assert "<https://example.com|link - text>" in result
 
 
-def test_convert_markdown_to_slack_whitespace_stripped(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_whitespace_stripped():
     """Test conversion strips leading/trailing whitespace"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text = "  Some text with spaces  "
     result = convert_markdown_to_slack(text)
-
     assert result == "Some text with spaces"
 
 
-def test_convert_markdown_to_slack_multiple_encoding_issues(mock_get_parameter: Mock, mock_env: Mock):
+def test_convert_markdown_to_slack_multiple_encoding_issues():
     """Test conversion handles multiple encoding issues"""
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import convert_markdown_to_slack
 
     text = "» Tab issue. â¢ Bullet point â¢ another bullet"
@@ -874,9 +713,16 @@ def test_convert_markdown_to_slack_multiple_encoding_issues(mock_get_parameter: 
 # ================================================================
 
 
-@patch("app.slack.slack_events.get_conversation_session_data")
+@patch("app.slack.slack_events.get_conversation_session_data", return_value={})
 @patch("app.slack.slack_events.process_formatted_bedrock_query")
-def test_process_slack_message_handles_conflict_exception(mock_env: Mock, mock_get_parameter: Mock):
+@patch("app.slack.slack_events.is_duplicate_event", return_value=False)
+def test_process_slack_message_handles_conflict_exception(
+    mock_is_duplicate: Mock,
+    mock_process_bedrock: Mock,
+    mock_get_session: Mock,
+    mock_env: Mock,
+    mock_get_parameter: Mock,
+):
     """
     GIVEN the bot has posted a 'Processing...' placeholder
     WHEN Bedrock throws a ConflictException due to a race condition on the session ID
@@ -886,89 +732,67 @@ def test_process_slack_message_handles_conflict_exception(mock_env: Mock, mock_g
     mock_client = Mock()
     mock_client.chat_postMessage.return_value = {"ts": "placeholder_ts_123"}
 
-    # Reload module to ensure clean state BEFORE patching
-    if "app.slack.slack_events" in sys.modules:
-        del sys.modules["app.slack.slack_events"]
     from app.slack.slack_events import process_slack_message
+    from botocore.exceptions import ClientError
+    from app.core.config import bot_messages
 
-    with patch("app.slack.slack_events.process_formatted_bedrock_query") as mock_process_bedrock:
+    error_response = {"Error": {"Code": "ConflictException", "Message": "Session is currently being used"}}
+    mock_process_bedrock.side_effect = ClientError(error_response, "RetrieveAndGenerate")
 
-        # Simulate the Bedrock race condition ConflictException
-        error_response = {"Error": {"Code": "ConflictException", "Message": "Session is currently being used"}}
-        mock_process_bedrock.side_effect = ClientError(error_response, "RetrieveAndGenerate")
+    event = {
+        "text": "<@U123> test question",
+        "user": "U456",
+        "channel": "D789",
+        "ts": "1234567890.123",
+        "event_ts": "1234567890.123",
+        "channel_type": "im",
+    }
 
-        event = {
-            "text": "<@U123> test question",
-            "user": "U456",
-            "channel": "C789",
-            "ts": "1234567890.123",
-            "event_ts": "123",
-            "channel_type": "channel",
-        }
+    process_slack_message(event=event, event_id="evt123", client=mock_client)
 
-        process_slack_message(event=event, event_id="evt123", client=mock_client)
-
-        mock_client.chat_postMessage.assert_called_once_with(
-            channel="C789", text="Processing...", thread_ts="1234567890.123"
-        )
-
-        mock_client.chat_update.assert_called_once_with(
-            channel="C789", ts="placeholder_ts_123", text="An error occurred, please try again.", blocks=[]
-        )
+    mock_client.chat_postMessage.assert_any_call(channel="D789", text="Processing...", thread_ts="1234567890.123")
+    mock_client.chat_postMessage.assert_any_call(
+        channel="D789", text=bot_messages.ERROR_RESPONSE, thread_ts="1234567890.123"
+    )
 
 
-def test_should_reply_to_message_rejects_raw_message_in_public_channel(mock_env: Mock):
+def test_should_reply_to_message_rejects_raw_message_in_public_channel():
     """
     GIVEN the bot is installed in a public channel
     WHEN a user @mentions the bot, firing a duplicate 'message' event alongside 'app_mention'
     THEN the 'message' event should be dropped to prevent a ConflictException race condition
     """
-    import sys
-
-    if "app.utils.handler_utils" in sys.modules:
-        del sys.modules["app.utils.handler_utils"]
     from app.utils.handler_utils import should_reply_to_message
 
     event = {"channel_type": "channel", "type": "message", "channel": "C123", "ts": "123"}
-
     result = should_reply_to_message(event)
 
     assert result is False
 
 
-def test_should_reply_to_message_accepts_app_mention_in_public_channel(mock_env: Mock):
+def test_should_reply_to_message_accepts_app_mention_in_public_channel():
     """
     GIVEN the bot is installed in a public channel
     WHEN a user @mentions the bot, firing the 'app_mention' event
     THEN the event should proceed normally without being blocked
     """
-    import sys
-
-    if "app.utils.handler_utils" in sys.modules:
-        del sys.modules["app.utils.handler_utils"]
     from app.utils.handler_utils import should_reply_to_message
 
     event = {"channel_type": "channel", "type": "app_mention", "channel": "C123", "ts": "123"}
-
     result = should_reply_to_message(event)
 
     assert result is True
 
 
-def test_should_reply_to_message_accepts_dm_message(mock_env: Mock):
+def test_should_reply_to_message_accepts_dm_message():
     """
     GIVEN the bot is installed
     WHEN a user DMs the bot with a prompt (which only fires a 'message' event)
     THEN the event should proceed normally without being blocked
     """
-    import sys
-
-    if "app.utils.handler_utils" in sys.modules:
-        del sys.modules["app.utils.handler_utils"]
     from app.utils.handler_utils import should_reply_to_message
 
     event = {"channel_type": "im", "type": "message", "channel": "D123", "ts": "123"}
-
     result = should_reply_to_message(event)
 
     assert result is True


### PR DESCRIPTION
## Summary

Prevent and/or gracefully handle message duplication.

### Details

When a bot is @'ed then the bot can receive multiple, duplicate, messages. This then fails when Bedrock received multiple messages with the same ID. 

This change does two things:
1. Save/ Checks MongoDB for IDs before starting the AI Process
2. Handles conflicts (and all errors) gracefully by informing the user to try again
