### PR TITLE
Fix: [AEA-6578] - Handle Secrets with KMS Keys

### DIFF
--- a/packages/cdk/constructs/SecretWithParameter.ts
+++ b/packages/cdk/constructs/SecretWithParameter.ts
@@ -2,12 +2,14 @@ import {Construct} from "constructs"
 import {SecretValue} from "aws-cdk-lib"
 import {StringParameter, ParameterTier} from "aws-cdk-lib/aws-ssm"
 import {Secret} from "aws-cdk-lib/aws-secretsmanager"
+import {Key} from "aws-cdk-lib/aws-kms"
 
 export interface SecretWithParameterProps {
   readonly secretName: string
   readonly parameterName: string
   readonly description: string
   readonly secretValue: string
+  readonly encryptionKey: Key
 }
 
 export class SecretWithParameter extends Construct {
@@ -21,7 +23,8 @@ export class SecretWithParameter extends Construct {
     const secret = new Secret(this, "Secret", {
       secretName: props.secretName,
       description: props.description,
-      secretStringValue: SecretValue.unsafePlainText(props.secretValue)
+      secretStringValue: SecretValue.unsafePlainText(props.secretValue),
+      encryptionKey: props.encryptionKey
     })
 
     // Create SSM parameter that references the secret

--- a/packages/cdk/resources/RuntimePolicies.ts
+++ b/packages/cdk/resources/RuntimePolicies.ts
@@ -18,6 +18,9 @@ export interface RuntimePoliciesProps {
   readonly reformulationModelId: string
   readonly docsBucketArn: string
   readonly docsBucketKmsKeyArn: string
+  readonly secretsKmsKeyArn: string
+  readonly slackBotTokenSecretArn: string
+  readonly slackSigningSecretArn: string
 }
 
 export class RuntimePolicies extends Construct {
@@ -65,6 +68,14 @@ export class RuntimePolicies extends Construct {
       ]
     })
 
+    const slackBotSecretPolicy = new PolicyStatement({
+      actions: ["secretsmanager:GetSecretValue"],
+      resources: [
+        props.slackBotTokenSecretArn,
+        props.slackSigningSecretArn
+      ]
+    })
+
     const slackBotLambdaPolicy = new PolicyStatement({
       actions: ["lambda:InvokeFunction"],
       resources: [`arn:aws:lambda:${props.region}:${props.account}:function:epsam*`]
@@ -97,7 +108,7 @@ export class RuntimePolicies extends Construct {
         "kms:GenerateDataKey",
         "kms:DescribeKey"
       ],
-      resources: [props.slackBotStateTableKmsKeyArn]
+      resources: [props.slackBotStateTableKmsKeyArn, props.secretsKmsKeyArn]
     })
 
     const slackBotDescribeCfStacks = new PolicyStatement({
@@ -116,6 +127,7 @@ export class RuntimePolicies extends Construct {
         slackBotPromptPolicy,
         slackBotKnowledgeBasePolicy,
         slackBotSSMPolicy,
+        slackBotSecretPolicy,
         slackBotLambdaPolicy,
         slackBotGuardrailPolicy,
         slackBotDynamoDbPolicy,
@@ -144,6 +156,14 @@ export class RuntimePolicies extends Construct {
       ]
     })
 
+    const syncKnowledgeBaseSecretPolicy = new PolicyStatement({
+      actions: ["secretsmanager:GetSecretValue"],
+      resources: [
+        props.slackBotTokenSecretArn,
+        props.slackSigningSecretArn
+      ]
+    })
+
     const knowledgeSyncDynamoDbPolicy = new PolicyStatement({
       actions: [
         "dynamodb:GetItem",
@@ -166,7 +186,7 @@ export class RuntimePolicies extends Construct {
         "kms:GenerateDataKey",
         "kms:DescribeKey"
       ],
-      resources: [props.knowledgeSyncStateTableKmsKeyArn]
+      resources: [props.knowledgeSyncStateTableKmsKeyArn, props.secretsKmsKeyArn]
     })
 
     this.syncKnowledgeBasePolicy = new ManagedPolicy(this, "SyncKnowledgeBasePolicy", {
@@ -174,6 +194,7 @@ export class RuntimePolicies extends Construct {
       statements: [
         syncKnowledgeBaseBedrockPolicy,
         syncKnowledgeBaseSSMPolicy,
+        syncKnowledgeBaseSecretPolicy,
         knowledgeSyncDynamoDbPolicy,
         knowledgeSyncKmsPolicy
       ]

--- a/packages/cdk/resources/Secrets.ts
+++ b/packages/cdk/resources/Secrets.ts
@@ -2,6 +2,7 @@ import {Construct} from "constructs"
 import {StringParameter} from "aws-cdk-lib/aws-ssm"
 import {Secret} from "aws-cdk-lib/aws-secretsmanager"
 import {SecretWithParameter} from "../constructs/SecretWithParameter"
+import {Key} from "aws-cdk-lib/aws-kms"
 
 export interface SecretsProps {
   readonly stackName: string
@@ -14,16 +15,24 @@ export class Secrets extends Construct {
   public readonly slackBotSigningSecret: Secret
   public readonly slackBotTokenParameter: StringParameter
   public readonly slackSigningSecretParameter: StringParameter
+  public readonly secretsKmsKey: Key
 
   constructor(scope: Construct, id: string, props: SecretsProps) {
     super(scope, id)
+
+    this.secretsKmsKey = new Key(this, "SecretsKmsKey", {
+      alias: `${props.stackName}-secrets-key`,
+      description: "KMS Key for EPS Assist Secrets",
+      enableKeyRotation: true
+    })
 
     // Create Slack bot OAuth token secret and parameter
     const slackBotToken = new SecretWithParameter(this, "SlackBotToken", {
       secretName: `/${props.stackName}/bot-token`,
       parameterName: `/${props.stackName}/bot-token/parameter`,
       description: "Slack Bot OAuth Token for EPS Assist",
-      secretValue: JSON.stringify({token: props.slackBotToken})
+      secretValue: JSON.stringify({token: props.slackBotToken}),
+      encryptionKey: this.secretsKmsKey
     })
 
     // Create Slack signing secret for request verification
@@ -31,7 +40,8 @@ export class Secrets extends Construct {
       secretName: `/${props.stackName}/signing-secret`,
       parameterName: `/${props.stackName}/signing-secret/parameter`,
       description: "Slack Signing Secret",
-      secretValue: JSON.stringify({secret: props.slackSigningSecret})
+      secretValue: JSON.stringify({secret: props.slackSigningSecret}),
+      encryptionKey: this.secretsKmsKey
     })
 
     // Export secrets and parameters for use by other constructs

--- a/packages/cdk/stacks/EpsAssistMeStack.ts
+++ b/packages/cdk/stacks/EpsAssistMeStack.ts
@@ -168,7 +168,10 @@ export class EpsAssistMeStack extends Stack {
       docsBucketArn: storage.kbDocsBucket.bucketArn,
       docsBucketKmsKeyArn: storage.kbDocsKmsKey.keyArn,
       knowledgeSyncStateTableArn: tables.knowledgeSyncStateTable.table.tableArn,
-      knowledgeSyncStateTableKmsKeyArn: tables.knowledgeSyncStateTable.kmsKey.keyArn
+      knowledgeSyncStateTableKmsKeyArn: tables.knowledgeSyncStateTable.kmsKey.keyArn,
+      secretsKmsKeyArn: secrets.secretsKmsKey.keyArn,
+      slackBotTokenSecretArn: secrets.slackBotTokenSecret.secretArn,
+      slackSigningSecretArn: secrets.slackBotSigningSecret.secretArn
     })
 
     // Create Functions construct with actual values from VectorKB


### PR DESCRIPTION
## Summary

Update handling of secrets to use KMS Keys

### Details

- Add KMS keys for Bot Token
- Add KMS keys for Signing Secret
- Encrypt secrets with KMS keys
- Add KMS to policies